### PR TITLE
Added adaptive non-maximal suppression. Fixes JIRA #71

### DIFF
--- a/autocnet/matcher/outlier_detector.py
+++ b/autocnet/matcher/outlier_detector.py
@@ -153,7 +153,7 @@ def compute_homography(kp1, kp2, outlier_algorithm=cv2.RANSAC, reproj_threshold=
 # TODO: CITATION and better design?
 def adaptive_non_max_suppression(keypoints, n=100, robust=0.9):
     """
-    Select the top n keypoints, using Adaptive Non-Maximal Suppression
+    Select the top n keypoints, using Adaptive Non-Maximal Suppression (see: Brown (2005) [Brown2005]_)
     to rank the keypoints in order of largest minimum suppression
     radius. A mask with only the positions of the top n keypoints set to 1 (and all else set to 0) is returned.
 

--- a/autocnet/matcher/outlier_detector.py
+++ b/autocnet/matcher/outlier_detector.py
@@ -1,5 +1,6 @@
 import cv2
 import numpy as np
+import pandas as pd
 
 
 def self_neighbors(matches):
@@ -148,5 +149,29 @@ def compute_homography(kp1, kp2, outlier_algorithm=cv2.RANSAC, reproj_threshold=
                                                      reproj_threshold)
     mask = mask.astype(bool)
     return transformation_matrix, mask
+
+
+# TODO: document me
+# right now, this is going to work on the un-merged dataframes... NOPE. I confused what was where again. Need the
+# graph for keypoint information...
+def adaptive_non_max_suppression(keypoints, n=20, robust=0.9):
+    minimum_suppression_radius = {}
+    for i, kp1 in enumerate(keypoints):
+        x1, y1 = kp1.pt
+        temp = []
+        for kp2 in keypoints: #includes kp1 for now
+            if kp1.response < robust*kp2.response:
+                x2, y2 = kp2.pt
+                temp.append(np.sqrt((x2-x1)**2 + (y2-y1)**2))
+        if(len(temp) > 0):
+            minimum_suppression_radius[i] = np.min(np.array(temp))
+        else:
+            minimum_suppression_radius[i] = [np.nan]
+    df = pd.DataFrame(list(minimum_suppression_radius.items()), columns=['keypoint_number', 'radius'])
+    new_df = df.sort_values(by='radius', ascending=False).head(n)
+    return new_df
+
+
+
 
 

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -6,12 +6,13 @@ from scipy.misc import imresize
 # TODO: look into KeyPoint.size and perhaps use to determine an appropriately-sized search/template.
 # TODO: do not allow even sizes
 
-"""
-Uses a pattern-matcher on subsets of two images determined from the passed-in keypoints and optional sizes to
-compute an x and y offset from the search keypoint to the template keypoint and an associated strength.
+def subpixel_offset(template_kp, search_kp, template_img, search_img, template_size=9, search_size=27, upsampling=10):
+    """
+    Uses a pattern-matcher on subsets of two images determined from the passed-in keypoints and optional sizes to
+    compute an x and y offset from the search keypoint to the template keypoint and an associated strength.
 
-Parameters
-----------
+    Parameters
+    ----------
     template_kp : KeyPoint
                   The KeyPoint to match the search_kp to.
     search_kp : KeyPoint
@@ -33,7 +34,6 @@ Parameters
       The returned tuple is of form: (x_offset, y_offset, strength). The offsets are from the search to the template
       keypoint.
     """
-def subpixel_offset(template_kp, search_kp, template_img, search_img, template_size=9, search_size=27, upsampling=10):
     # Get the x,y coordinates
     temp_x, temp_y = map(int, template_kp.pt)
     search_x, search_y = map(int, search_kp.pt)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,7 +295,7 @@ class Mock(MagicMock):
 
 # All imported libraries should be added to this mock modules list.
 MOCK_MODULES = ['proj4', 'numpy', 'pandas', 'scipy', 'osgeo', 'cv2',
-                'scikit-image', 'skimage']
+                'scikit-image', 'skimage', 'skimage.feature', 'scipy', 'scipy.misc']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # NumpyDoc Options

--- a/docs/library/matcher/index.rst
+++ b/docs/library/matcher/index.rst
@@ -5,3 +5,6 @@
 
    feature_extractor
    matcher
+   outlier_detector
+   subpixel
+   

--- a/docs/library/matcher/outlier_detector.rst
+++ b/docs/library/matcher/outlier_detector.rst
@@ -1,0 +1,10 @@
+:mod:`matcher.outlier_detector` --- Finding outliers in both the keypoints and the matches
+====================================================================
+
+The :mod:`matcher.outlier_detector` module
+
+.. versionadded:: 0.1.0
+
+.. automodule:: autocnet.matcher.outlier_detector
+   :synopsis:
+   :members:

--- a/docs/library/matcher/subpixel.rst
+++ b/docs/library/matcher/subpixel.rst
@@ -1,0 +1,11 @@
+:mod:`matcher.subpixel` --- Performing subpixel registration between images
+====================================================================
+
+The :mod:`matcher.subpixel` module
+
+.. versionadded:: 0.1.0
+
+.. automodule:: autocnet.matcher.subpixel
+   :synopsis:
+   :members:
+

--- a/docs/library/matcher/subpixel.rst
+++ b/docs/library/matcher/subpixel.rst
@@ -8,4 +8,3 @@ The :mod:`matcher.subpixel` module
 .. automodule:: autocnet.matcher.subpixel
    :synopsis:
    :members:
-

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -3,4 +3,5 @@
 References
 ==========
 
-.. [Lowe2003] Lowe, David G. (2004). Distinctive Image Features from Scale-Invariant Keypoints. International Journal of Computer Vision. 60 (2), p. 91 - 110.
+.. [Lowe2004] Lowe, David G. (2004). Distinctive Image Features from Scale-Invariant Keypoints. International Journal of Computer Vision. 60 (2), p. 91 - 110.
+.. [Brown2005] Brown, M., Szeliski, R., and Widner, S. (2005). Multi-image matching using multi-scale oriented patches. IEEE Computer Society Conference on Computer Vision and Pattern Recognition (CVPR 2005). p. 510-517

--- a/functional_tests/test_two_image.py
+++ b/functional_tests/test_two_image.py
@@ -49,10 +49,10 @@ class TestTwoImageMatching(unittest.TestCase):
         for node, attributes in cg.nodes_iter(data=True):
             self.assertIn(len(attributes['keypoints']), range(490, 511))
 
-        # Step: apply ANMS
+        # Step: apply Adaptive non-maximal suppression
         for node, attributes in cg.nodes_iter(data=True):
-            print(od.adaptive_non_max_suppression(attributes['keypoints']))
-        self.assertTrue(False)
+            attributes['keypoint_mask'] = od.adaptive_non_max_suppression(attributes['keypoints'])
+            self.assertEqual(len(attributes['keypoint_mask']), len(attributes['keypoints']))
 
         # Step: Then apply a FLANN matcher
         fl = FlannMatcher()

--- a/functional_tests/test_two_image.py
+++ b/functional_tests/test_two_image.py
@@ -49,6 +49,11 @@ class TestTwoImageMatching(unittest.TestCase):
         for node, attributes in cg.nodes_iter(data=True):
             self.assertIn(len(attributes['keypoints']), range(490, 511))
 
+        # Step: apply ANMS
+        for node, attributes in cg.nodes_iter(data=True):
+            print(od.adaptive_non_max_suppression(attributes['keypoints']))
+        self.assertTrue(False)
+
         # Step: Then apply a FLANN matcher
         fl = FlannMatcher()
         for node, attributes in cg.nodes_iter(data=True):


### PR DESCRIPTION
Added adaptive_non_max_suppression, which will compute and return a mask for the keypoint list we have stored as an attribute for each node. The mask will have 1's in the places of the top n maximum minimum distances to another point that is significantly stronger. See http://graphics.cs.cmu.edu/courses/15-463/2005_fall/www/Papers/MOPS.pdf for more information.
