### PR TITLE
Added ability to produce a fromlist (for isis) from the graph. References JIRA #83

### DIFF
--- a/autocnet/fileio/io_controlnetwork.py
+++ b/autocnet/fileio/io_controlnetwork.py
@@ -10,6 +10,23 @@ HEADERSTARTBYTE = 65536
 DEFAULTUSERNAME = 'AutoControlNetGeneration'
 
 
+def write_filelist(lst, path="fromlist.lis"):
+    """
+    Writes a filelist to a file so it can be used in ISIS3.
+
+    Parameters
+    ----------
+    lst : list
+          A list containing full paths to the images used, as strings.
+    path : str
+           The name of the file to write out. Default: fromlist.lis
+    """
+    handle = open(path, 'w')
+    for filename in lst:
+        handle.write(filename)
+        handle.write('\n')
+    return
+
 def to_isis(path, C, mode='w', version=VERSION,
             headerstartbyte=HEADERSTARTBYTE,
             networkid='None', targetname='None',

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -375,6 +375,20 @@ class CandidateGraph(nx.Graph):
                                                                                  'correlation'])
             attributes['subpixel'] = mask
 
+    def to_filelist(self):
+        """
+        Generate a file list for the entire graph.
+
+        Returns
+        -------
+        filelist : list
+                   A list where each entry is a string containing the full path to an image in the graph.
+        """
+        filelist = []
+        for node in self.nodes_iter(data=True):
+            filelist.append(node[1]['image_path'])
+        return filelist
+
     def to_cnet(self, clean_keys=[]):
         """
         Generate a control network (C) object from a graph
@@ -422,6 +436,7 @@ class CandidateGraph(nx.Graph):
         merged_cnet = None
 
         for source, destination, attributes in self.edges_iter(data=True):
+
             matches = attributes['matches']
 
             # Merge all of the masks

--- a/functional_tests/test_three_image.py
+++ b/functional_tests/test_three_image.py
@@ -2,6 +2,7 @@ import unittest
 
 from autocnet.examples import get_path
 from autocnet.fileio.io_controlnetwork import to_isis
+from autocnet.fileio.io_controlnetwork import write_filelist
 from autocnet.graph.network import CandidateGraph
 from autocnet.matcher.matcher import FlannMatcher
 from autocnet.matcher import outlier_detector as od
@@ -71,6 +72,10 @@ class TestThreeImageMatching(unittest.TestCase):
         # Step: And create a C object
         cnet = cg.to_cnet(clean_keys=['symmetry', 'ratio', 'ransac'])
 
+        # Step: Create a fromlist to go with the cnet and write it to a file
+        filelist = cg.to_filelist()
+        write_filelist(filelist, 'TestThreeImageMatching_fromlist.lis')
+
         # Step update the serial numbers
         nid_to_serial = {}
         for node, attributes in cg.nodes_iter(data=True):
@@ -84,4 +89,5 @@ class TestThreeImageMatching(unittest.TestCase):
     def tearDown(self):
         try:
             os.path.remove('TestThreeImageMatching.net')
+            os.path.remove('TestThreeImageMatching_fromlist.lis')
         except: pass

--- a/functional_tests/test_two_image.py
+++ b/functional_tests/test_two_image.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from autocnet.examples import get_path
 from autocnet.fileio.io_controlnetwork import to_isis
+from autocnet.fileio.io_controlnetwork import write_filelist
 from autocnet.graph.network import CandidateGraph
 from autocnet.matcher.matcher import FlannMatcher
 from autocnet.matcher import outlier_detector as od
@@ -88,6 +89,11 @@ class TestTwoImageMatching(unittest.TestCase):
 
         # Step: And create a C object
         cnet = cg.to_cnet(clean_keys=['symmetry', 'ratio', 'ransac', 'subpixel'])
+
+        # Step: Create a fromlist to go with the cnet and write it to a file
+        filelist = cg.to_filelist()
+        write_filelist(filelist)
+
         # Step update the serial numbers
         nid_to_serial = {}
         for node, attributes in cg.nodes_iter(data=True):
@@ -102,4 +108,5 @@ class TestTwoImageMatching(unittest.TestCase):
     def tearDown(self):
         try:
             os.path.remove('TestTwoImageMatching.net')
+            os.path.remove('fromlist.lis')
         except: pass


### PR DESCRIPTION
I added the ability for **the graph** to produce a fromlist (and then later write it to a file), since the fromlist only cares about which images are included. Right now we start with an adjacency dict we turn into a graph, so we know that all nodes(images) should be included in the output fromlist. 

This is very simplistic, so please let me know if any of my above assumptions are wrong or anything else needs to be changed! We could later call this on a connected-subgraph to produce the fromlist for a connected subset of images. 