### PR TITLE
Adding Minimum Spanning Tree Method to CandidateGraph

### DIFF
--- a/autocnet/graph/tests/test_network.py
+++ b/autocnet/graph/tests/test_network.py
@@ -99,3 +99,27 @@ class TestEdge(unittest.TestCase):
     def setUpClass(cls):
         cls.graph = network.CandidateGraph.from_adjacency(get_path('adjacency.json'))
 
+
+class TestMSTGraph(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.test_dict = {"0": ["4", "2", "1", "3"],
+                         "1": ["0", "3", "2", "6", "5"],
+                         "2": ["1", "0", "3", "4", "7"],
+                         "3": ["2", "0", "1", "5"],
+                         "4": ["2", "0"],
+                         "5": ["1", "3"],
+                         "6": ["1"],
+                         "7": ["2"]}
+
+        cls.graph = network.CandidateGraph.from_adjacency(cls.test_dict)
+        cls.graph.minimum_spanning_tree()
+        cls.mst_graph = cls.graph.copy()
+
+        for s, d, edge in cls.graph.edges_iter(data=True):
+            if not cls.graph.graph_masks['mst'][(s, d)]:
+                cls.mst_graph.remove_edge(s, d)
+
+    def test_mst_output(self):
+        self.assertEqual(self.mst_graph.nodes(), self.graph.nodes())
+        self.assertEqual(self.mst_graph.number_of_edges(), self.graph.number_of_edges()-5)

--- a/autocnet/graph/tests/test_network.py
+++ b/autocnet/graph/tests/test_network.py
@@ -40,6 +40,23 @@ class TestCandidateGraph(unittest.TestCase):
     def test_island_nodes(self):
         self.assertEqual(len(self.disconnected_graph.island_nodes()), 1)
 
+    def test_apply_func_to_edges(self):
+        graph = self.graph.copy()
+        graph.minimum_spanning_tree()
+
+        try:
+            graph.apply_func_to_edges('incorrect_func')
+        except AttributeError:
+            pass
+
+        graph.extract_features(extractor_parameters={'nfeatures': 500})
+        graph.match_features()
+        graph.apply_func_to_edges("symmetry_check", graph_mask_keys=['mst'])
+
+        self.assertFalse(graph[0][2].masks['symmetry'].all())
+        self.assertFalse(graph[0][1].masks['symmetry'].all())
+        self.assertTrue(graph[1][2].masks['symmetry'].all())
+
     def test_connected_subgraphs(self):
         subgraph_list = self.disconnected_graph.connected_subgraphs()
         self.assertEqual(len(subgraph_list), 2)
@@ -100,7 +117,7 @@ class TestEdge(unittest.TestCase):
         cls.graph = network.CandidateGraph.from_adjacency(get_path('adjacency.json'))
 
 
-class TestMSTGraph(unittest.TestCase):
+class TestGraphMasks(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.test_dict = {"0": ["4", "2", "1", "3"],


### PR DESCRIPTION
The mst in a Pandas DataFrame as a boolean mask. The DataFrame now an attribute of CandidateGraph.