### PR TITLE
Basic 'calculate overlap' funcationality working* on cubes

### DIFF
--- a/autocnet/graph/tests/test_network.py
+++ b/autocnet/graph/tests/test_network.py
@@ -76,6 +76,20 @@ class TestFromList(unittest.TestCase):
 
     def test_graph_length(self):
         self.assertEqual(self.graph.__len__(), 3)
+        self.assertEqual(self.graph.number_of_nodes(), 3)
+
+class TestFromListCubes(unittest.TestCase):
+    @classmethod
+
+    def setUpClass(cls):
+        filelist = [get_path('AS15-M-0297_sub4.cub'),
+                    get_path('AS15-M-0298_sub4.cub'),
+                    get_path('AS15-M-0299_sub4.cub')]
+        cls.graph = network.CandidateGraph.from_filelist(filelist)
+
+    def test_graph_length(self):
+        self.assertEqual(self.graph.number_of_nodes(), 3)
+        self.assertEqual(self.graph.number_of_edges(), 3)
 
 class TestEdge(unittest.TestCase):
 


### PR DESCRIPTION
This seems to be working, but I didn't test it very well (see my tests.)

latlon_extent is not used for Cubes right now. I added _pvl_header and _footprint_polygon to GeoDataset to support Cubes.

I'm not sure that reorganizing footprint_polygon.GetEnvelope() into the right shape for a bounding box is doing the right thing, so someone should double-check.