### PR TITLE
fixed mst node comparison issue

### DIFF
--- a/autocnet/graph/tests/test_network.py
+++ b/autocnet/graph/tests/test_network.py
@@ -138,5 +138,5 @@ class TestGraphMasks(unittest.TestCase):
                 cls.mst_graph.remove_edge(s, d)
 
     def test_mst_output(self):
-        self.assertEqual(self.mst_graph.nodes(), self.graph.nodes())
+        self.assertEqual(set(self.mst_graph.nodes()), set(self.graph.nodes()))
         self.assertEqual(self.mst_graph.number_of_edges(), self.graph.number_of_edges()-5)


### PR DESCRIPTION
This concerns a problem where the second mst graph in `TestGraphMasks`might have it's nodes slightly out of order after mst computation on rare occasions. This causes the node list comparison to fail even though node order is inconsequential.   