### PR TITLE
Fix for GeoDataset.foorprint failing on read-only cubes 

### DIFF
--- a/autocnet/fileio/io_gdal.py
+++ b/autocnet/fileio/io_gdal.py
@@ -237,7 +237,7 @@ class GeoDataset(object):
                 num_polygon_bytes = find_in_dict(polygon_pvl, 'Bytes')
 
                 # I too dislike the additional open here.  Not sure a good option
-                with open(self.file_name, 'r+') as f:
+                with open(self.file_name, 'r') as f:
                     f.seek(start_polygon_byte - 1)
                     # Sloppy unicode to string because GDAL pukes on unicode
                     stream = str(f.read(num_polygon_bytes))


### PR DESCRIPTION
It doesn't look like we actually need write permission, so I changed r -> r+