### PR TITLE
added robustness to poor footprints

### DIFF
--- a/autocnet/fileio/io_utils.py
+++ b/autocnet/fileio/io_utils.py
@@ -22,3 +22,12 @@ def delete_dir(dir):
           Remove a directory
     """
     shutil.rmtree(dir)
+
+
+def file_to_list(file):
+    with open(file, 'r') as f:
+        file_list = f.readlines()
+        file_list = map(str.rstrip, file_list)
+        file_list = filter(None, file_list)
+
+    return file_list

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -8,6 +8,7 @@ import pandas as pd
 import warnings
 
 from autocnet.fileio.io_gdal import GeoDataset
+from autocnet.fileio import io_utils
 from autocnet.fileio import io_hdf
 from autocnet.control.control import C
 from autocnet.fileio import io_json
@@ -108,11 +109,8 @@ class CandidateGraph(nx.Graph):
         : object
           A Network graph object
         """
-        if not isinstance(filelist, list):
-            with open(filelist, 'r') as f:
-                filelist = f.readlines()
-                filelist = map(str.rstrip, filelist)
-                filelist = filter(None, filelist)
+        if isinstance(filelist, str):
+            filelist = io_utils.file_to_list(filelist)
 
         # TODO: Reject unsupported file formats + work with more file formats
         if basepath:
@@ -124,7 +122,6 @@ class CandidateGraph(nx.Graph):
         adjacency_dict = {}
         valid_datasets = []
 
-        # filter bad/malformed footprints
         for i in datasets:
             adjacency_dict[i.file_name] = []
 
@@ -144,7 +141,7 @@ class CandidateGraph(nx.Graph):
                     adjacency_dict[i.file_name].append(j.file_name)
                     adjacency_dict[j.file_name].append(i.file_name)
             except:
-                warnings.warn('Failed to calculated intersection between {} and {}'.format(i,j))
+                warnings.warn('Failed to calculated intersection between {} and {}'.format(i, j))
 
         return cls(adjacency_dict)
 


### PR DESCRIPTION
This should give added robustness when dealing with polys that fail both the PVL and lat/lon check. Also added robustness when dealing with polys that pass the checks but still generate an invalid polygon. 

Calls to `match_features()` should no longer fail in the presence of isolated vertices. 