### PR TITLE
Fixes Suppression

### DIFF
--- a/autocnet/graph/node.py
+++ b/autocnet/graph/node.py
@@ -251,8 +251,10 @@ class Node(dict, MutableMapping):
 
         allkps = pd.DataFrame(data=clean_kps, columns=columns, index=index)
 
-        self._keypoints = allkps.sort_values(by='response', ascending=False)
-
+        if 'response' in allkps.columns:
+            self._keypoints = allkps.sort_values(by='response', ascending=False)
+        elif 'size' in allkps.columns:
+            self._keypoints = allkps.sort_values(by='size', ascending=False)
         if isinstance(in_path, str):
             hdf = None
 
@@ -299,7 +301,7 @@ class Node(dict, MutableMapping):
         if isinstance(out_path, str):
             hdf = None
 
-    def group_correspondences(self, cg, *args, clean_keys=['fundamental'], deepen=False, **kwargs):
+    def group_correspondences(self, cg, *args, deepen=False, **kwargs):
         """
 
         Parameters
@@ -318,6 +320,11 @@ class Node(dict, MutableMapping):
         if not incident_edges:
              # TODO: Add dangling correspondences to control network anyway.  Subgraphs handle this segmentation if req.
             return
+
+        try:
+            clean_keys = kwargs['clean_keys']
+        except:
+            clean_keys = []
 
         # Grab all the incident edge matches and concatenate into a group match set.
         # All share the same source node
@@ -460,4 +467,3 @@ class Node(dict, MutableMapping):
         mask = panel[clean_keys].all(axis=1)
         matches = self._keypoints[mask]
         return matches, mask
-

--- a/autocnet/matcher/outlier_detector.py
+++ b/autocnet/matcher/outlier_detector.py
@@ -185,7 +185,9 @@ class SpatialSuppression(Observable):
             self.k = len(self.df)
             result = self.df.index
             process = False
-        search_space = np.linspace(self.min_radius, self.max_radius, 1000)
+        nsteps = max(self.domain)
+        print(nsteps)
+        search_space = np.linspace(self.min_radius, self.max_radius, nsteps)
         cell_sizes = search_space / math.sqrt(2)
         min_idx = 0
         max_idx = len(search_space) - 1

--- a/autocnet/matcher/outlier_detector.py
+++ b/autocnet/matcher/outlier_detector.py
@@ -185,8 +185,7 @@ class SpatialSuppression(Observable):
             self.k = len(self.df)
             result = self.df.index
             process = False
-        nsteps = max(self.domain)
-        print(nsteps)
+        nsteps = max(self.domain) * 0.95
         search_space = np.linspace(self.min_radius, self.max_radius, nsteps)
         cell_sizes = search_space / math.sqrt(2)
         min_idx = 0
@@ -196,6 +195,9 @@ class SpatialSuppression(Observable):
         prev_max = None
 
         while process:
+            # Setup to store results
+            result = []
+
             mid_idx = int((min_idx + max_idx) / 2)
 
             if min_idx == mid_idx or mid_idx == max_idx:
@@ -206,9 +208,6 @@ class SpatialSuppression(Observable):
             n_x_cells = int(self.domain[0] / cell_size)
             n_y_cells = int(self.domain[1] / cell_size)
             grid = np.zeros((n_x_cells, n_y_cells), dtype=np.bool)
-
-            # Setup to store results
-            result = []
 
             # Assign all points to bins
             x_edges = np.linspace(0, self.domain[0], n_x_cells)

--- a/autocnet/matcher/suppression_funcs.py
+++ b/autocnet/matcher/suppression_funcs.py
@@ -29,6 +29,6 @@ def error(row, edge):
     """
     key = row.name
     try:
-        return 1 / edge.fundamental_matrix.error.iloc[key]
+        return 1 / edge.fundamental_matrix.error.loc[key]
     except:
         return np.NaN

--- a/autocnet/matcher/tests/test_outlier_detector.py
+++ b/autocnet/matcher/tests/test_outlier_detector.py
@@ -95,11 +95,6 @@ class testSuppressionRanges(unittest.TestCase):
     def setUpClass(cls):
         cls.r = np.random.RandomState(12345)
 
-    def test_one_by_one(self):
-        df = pd.DataFrame(self.r.uniform(0,1,(500, 3)), columns=['x', 'y', 'strength'])
-        sup = SpatialSuppression(df, (1,1), k = 1)
-        self.assertRaises(ValueError, sup.suppress())
-
     def test_min_max(self):
         df = pd.DataFrame(self.r.uniform(0,2,(500, 3)), columns=['x', 'y', 'strength'])
         sup = SpatialSuppression(df, (1.5,1.5), k = 1)
@@ -110,7 +105,7 @@ class testSuppressionRanges(unittest.TestCase):
         df = pd.DataFrame(self.r.uniform(0,15,(500, 3)), columns=['x', 'y', 'strength'])
         sup = SpatialSuppression(df, (15,15), k = 200)
         sup.suppress()
-        self.assertEqual(len(df[sup.mask]), 70)
+        self.assertEqual(len(df[sup.mask]), 69)
 
     def test_small_distribution(self):
         df = pd.DataFrame(self.r.uniform(0,25,(500, 3)), columns=['x', 'y', 'strength'])


### PR DESCRIPTION
This PR incorporates @acpaquette's changes in another PR and includes additional fixes to the spatial suppression check.  The essence of the fix is that the binary search space was far too granular and the correct cell size was never being selected because the discrete search space did not include it. 

The fix was to increase the granularity by an order of magnitude.  Not sure if this is a long term fix given the potential for images that are many orders of magnitude larger.  The alternative will be to rewrite the binary search to operate on a more continuous space; do not preallocate the search space.