### PR TITLE
"overlap" keypoint constraint & match mask

### DIFF
--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -442,6 +442,18 @@ class CandidateGraph(nx.Graph):
         '''
         self.apply_func_to_edges('ratio_check', *args, **kwargs)
 
+    def compute_overlaps(self, *args, **kwargs):
+        '''
+        Computes overlap MBRs for all edges
+        '''
+        self.apply_func_to_edges('compute_overlap', *args, **kwargs)
+
+    def overlap_checks(self, *args, **kwargs):
+        '''
+        Apply overlap check to all edges in the graph
+        '''
+        self.apply_func_to_edges('overlap_check', *args, **kwargs)
+
     def compute_homographies(self, *args, **kwargs):
         '''
         Compute homographies for all edges using identical parameters

--- a/autocnet/matcher/cpu_decompose.py
+++ b/autocnet/matcher/cpu_decompose.py
@@ -6,7 +6,7 @@ from autocnet.matcher.cpu_matcher import match
 from autocnet.transformation.decompose import coupled_decomposition
 
 
-def decompose_and_match(self, k=2, maxiteration=3, size=18, buf_dist=3,**kwargs):
+def decompose_and_match(self, k=2, maxiteration=3, size=18, buf_dist=3, **kwargs):
     """
     Similar to match, this method first decomposed the image into
     $4^{maxiteration}$ subimages and applys matching between each sub-image.
@@ -67,8 +67,9 @@ def decompose_and_match(self, k=2, maxiteration=3, size=18, buf_dist=3,**kwargs)
     dsize = ddata.shape
 
     # Grab all the available candidate keypoints
-    skp = self.source.get_keypoints()
-    dkp = self.destination.get_keypoints()
+    overlap = kwargs.get("overlap", False)
+    skp = self.get_keypoints(self.source, overlap=overlap)
+    dkp = self.get_keypoints(self.destination, overlap=overlap)
 
     # Set up the membership arrays
     self.smembership = np.zeros(sdata.shape, dtype=np.int16)

--- a/autocnet/matcher/cpu_matcher.py
+++ b/autocnet/matcher/cpu_matcher.py
@@ -8,7 +8,7 @@ FLANN_INDEX_KDTREE = 1  # Algorithm to set centers,
 DEFAULT_FLANN_PARAMETERS = dict(algorithm=FLANN_INDEX_KDTREE, trees=3)
 
 
-def match(self, k=2, overlap=[], **kwargs):
+def match(self, k=2, **kwargs):
     """
     Given two sets of descriptors, utilize a FLANN (Approximate Nearest
     Neighbor KDTree) matcher to find the k nearest matches.  Nearness is
@@ -83,21 +83,12 @@ def match(self, k=2, overlap=[], **kwargs):
     if 'aidx' in kwargs.keys():
         aidx = kwargs['aidx']
         kwargs.pop('aidx')
-    elif overlap:
-        # Query the source keypoints for those in the MBR
-        source_mbr = overlap[0]
-        query_result = self.source.keypoints.query('x >= {} and x <= {} and y >= {} and y <= {}'.format(*source_mbr))
-        aidx = query_result.index
     else:
         aidx = None
     
     if 'bidx' in kwargs.keys():
         bidx = kwargs['bidx']
         kwargs.pop('bidx')
-    elif overlap:
-        destin_mbr = overlap[1]
-        query_result = self.destination.keypoints.query('x >= {} and x <= {} and y >= {} and y <= {}'.format(*destin_mbr))
-        bidx = query_result.index
     else:
         bidx = None
 

--- a/autocnet/matcher/cuda_matcher.py
+++ b/autocnet/matcher/cuda_matcher.py
@@ -4,7 +4,7 @@ import cudasift as cs
 import numpy as np
 import pandas as pd
 
-def match(self, ratio=0.8, overlap=[], **kwargs):
+def match(self, ratio=0.8, **kwargs):
 
     """
     Apply a composite CUDA matcher and ratio check.  If this method is used,
@@ -14,24 +14,11 @@ def match(self, ratio=0.8, overlap=[], **kwargs):
     without significant gain in accuracy when using this implementation.
     """
 
-    if overlap:
-        source_overlap = overlap[0]
-        source_kps = self.source.keypoints.query('x >= {} and x <= {} and y >= {} and y <= {}'.format(*source_overlap))
-        idx = source_kps.index
-        sremap = {k:v for k, v in enumerate(idx)}
-        source_des = self.source.descriptors[idx]
+    source_kps = self.source.get_keypoints()
+    source_des = self.source.descriptors
 
-        destin_overlap = overlap[1]
-        destin_kps = self.destination.keypoints.query('x >= {} and x <= {} and y >= {} and y <= {}'.format(*destin_overlap))
-        idx = destin_kps.index
-        dremap = {k:v for k, v in enumerate(idx)}
-        destin_des = self.destination.descriptors[idx]
-    else:
-        source_kps = self.source.get_keypoints()
-        source_des = self.source.descriptors
-
-        destin_kps = self.destination.get_keypoints()
-        destin_des = self.destination.descriptors
+    destin_kps = self.destination.get_keypoints()
+    destin_des = self.destination.descriptors
 
     s_siftdata = cs.PySiftData.from_data_frame(source_kps, source_des)
     d_siftdata = cs.PySiftData.from_data_frame(destin_kps, destin_des)
@@ -44,15 +31,10 @@ def match(self, ratio=0.8, overlap=[], **kwargs):
     destination[:] = self.destination['node_id']
 
     df = pd.concat([pd.Series(source), pd.Series(matches.index),
-		    pd.Series(destination), matches.match,
-		    matches.score, matches.ambiguity], axis=1)
+            pd.Series(destination), matches.match,
+            matches.score, matches.ambiguity], axis=1)
     df.columns = ['source_image', 'source_idx', 'destination_image',
-		    'destination_idx', 'score', 'ambiguity']
-
-
-    if overlap:
-        df['source_idx'].replace(sremap, inplace=True)
-        df['destination_idx'].replace(dremap, inplace=True)
+            'destination_idx', 'score', 'ambiguity']
 
     # Set the matches and set the 'ratio' (ambiguity) mask
     self.matches = df


### PR DESCRIPTION
- overlap=bool param for Edge.get_keypoints(); Masks returned keypoints that aren't within their Node's MBR
- Edge.overlap_check() that populates Edge.masks["overlap"]; Masks matches whose keypoints aren't within their Node's MBR
- Unit tests for both of the above