### PR TITLE
improving conda commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,4 +47,4 @@ We suggest using Anaconda Python to install Autocnet within a virtual environmen
    * ``conda config --env --add channels conda-forge``
    * ``conda config --env --add channels menpo``
    * ``conda config --env --add channels usgs-astrogeology``
-#. Finally, install autocnet: ``conda install autocnet-dev``
+#. Finally, install autocnet: ``conda install autocnet``

--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,13 @@ We suggest using Anaconda Python to install Autocnet within a virtual environmen
    * ``conda create -n <your_environment_name> python=3 && source activate <your_environment_name>``
    
    Note, that you might want to specify either ``python=3.5`` or ``python=3.6``, depending on your requirements. Both are currently supported by autocnet.
-#. Bring up a command line and add three channels to your conda config (``~/condarc``):
+#. Make the newly created environment the active one:
+
+   * ``conda activate <your_environment_name>`` (or ``source activate`` on an older conda system)
    
-   * ``conda config --add channels conda-forge``
-   * ``conda config --add channels menpo``
-   * ``conda config --add channels usgs-astrogeology``
-#. Finally, install autocnet: ``conda install -c usgs-astrogeology autocnet``
+#. Bring up a command line and add three channels to your conda environment-specific config file:
+   
+   * ``conda config --env --add channels conda-forge``
+   * ``conda config --env --add channels menpo``
+   * ``conda config --env --add channels usgs-astrogeology``
+#. Finally, install autocnet: ``conda install autocnet-dev``


### PR DESCRIPTION
The addition of channels like menpo and conda-forge drastically change the dependency chain, so it's better to have these configurations only added for the newly created environment. This is achieved by adding the `--env` option to the `conda config` command.
Also, after adding the `usgs-astrogeology` channel, it's not required in the `install` command.