### PR TITLE
Adds pip to the environment file to fix pip warning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - numpy
   - opencv
   - pillow
+  - pip
   - pip:
     - redis
   - plio >= 1.1.0


### PR DESCRIPTION
Found this when setting up an env. This removes the `pip` warning.