### PR TITLE
Performance improvement in sql overlap

### DIFF
--- a/sql/compute_overlapping_geometries.sql
+++ b/sql/compute_overlapping_geometries.sql
@@ -15,7 +15,7 @@ FROM (
 		SELECT overlay.id, array_agg(images.id) as iid
 		FROM overlay, images
 		WHERE images.footprint_latlon is NOT NULL AND
-		WHERE ST_INTERSECTS(overlay.geom, images.footprint_latlon) AND
+		ST_INTERSECTS(overlay.geom, images.footprint_latlon) AND
 		ST_AREA(ST_INTERSECTION(overlay.geom, images.footprint_latlon)) > 0.000001
 		GROUP BY overlay.id
 	) AS imgs

--- a/sql/compute_overlapping_geometries.sql
+++ b/sql/compute_overlapping_geometries.sql
@@ -15,6 +15,7 @@ FROM (
 		SELECT overlay.id, array_agg(images.id) as iid
 		FROM overlay, images
 		WHERE images.footprint_latlon is NOT NULL AND
+		WHERE ST_INTERSECTS(overlay.geom, images.footprint_latlon) AND
 		ST_AREA(ST_INTERSECTION(overlay.geom, images.footprint_latlon)) > 0.000001
 		GROUP BY overlay.id
 	) AS imgs


### PR DESCRIPTION
This adds an ST_INTERSECT query to the inner query as a performance improvement. I believe that the query planner should use that WHERE statement first and then perform the actual intersections. This should take the inner query from best case n^2 to worst case n^2.