### PR TITLE
Empty footprint

### DIFF
--- a/autocnet/graph/node.py
+++ b/autocnet/graph/node.py
@@ -510,7 +510,6 @@ class NetworkNode(Node):
         # For now, just use the PATH to determine if the node/image is in the DB
         res = session.query(Images).filter(Images.path == kwargs['image_path']).first()
         if res is None:
-            print('inserting', kwargs['image_path'])
             kpspath = io_keypoints.create_output_path(self.geodata.file_name)
 
             # Create the keypoints entry

--- a/autocnet/graph/node.py
+++ b/autocnet/graph/node.py
@@ -510,6 +510,7 @@ class NetworkNode(Node):
         # For now, just use the PATH to determine if the node/image is in the DB
         res = session.query(Images).filter(Images.path == kwargs['image_path']).first()
         if res is None:
+            print('inserting', kwargs['image_path'])
             kpspath = io_keypoints.create_output_path(self.geodata.file_name)
 
             # Create the keypoints entry
@@ -517,7 +518,8 @@ class NetworkNode(Node):
             cam = self.create_camera()
             try:
                 fp = self.footprint
-            except:
+            except Exception as e:
+                warnings.warn('Unable to generate image footprint.\n{}'.format(e))
                 fp = None
             # Create the image
             i = Images(name=kwargs['image_name'],

--- a/autocnet/io/db/model.py
+++ b/autocnet/io/db/model.py
@@ -226,7 +226,10 @@ class Images(BaseMixin, Base):
         if isinstance(geom, osgeo.ogr.Geometry):
             # If an OGR geom, convert to shapely
             geom = shapely.wkt.loads(geom.ExportToWkt())
-        self._footprint_latlon = from_shape(geom, srid=srid)
+        if geom is None:
+            self._footprint_latlon = None
+        else:
+            self._footprint_latlon = from_shape(geom, srid=srid)
 
 class Overlay(BaseMixin, Base):
     __tablename__ = 'overlay'
@@ -290,7 +293,7 @@ class Points(BaseMixin, Base):
         if isinstance(v, int):
             v = PointType(v)
         self._pointtype = v
-        
+
 class MeasureType(enum.IntEnum):
     """
     Enum to enforce measure type for ISIS control networks

--- a/autocnet/io/db/tests/test_model.py
+++ b/autocnet/io/db/tests/test_model.py
@@ -169,6 +169,11 @@ def test_jigsaw_append(mockFunc, session, measure_data, point_data, image_data):
     assert resp.liner == 0.1
     assert resp.sampler == 0.1
 
+def test_null_footprint(session):
+    i = model.Images.create(session, footprint_latlon=None,
+                                      serial = 'serial')
+    assert i.footprint_latlon is None
+
 def test_broken_bad_geom(session):
     # An irreperablly damaged poly
     geom = MultiPolygon([Polygon([(0,0), (1,1), (1,2), (1,1), (0,0)])])
@@ -176,7 +181,7 @@ def test_broken_bad_geom(session):
                                       serial = 'serial')
     resp = session.query(model.Images).filter(model.Images.id==i.id).one()
     assert resp.active == False
-    
+
 def test_fix_bad_geom(session):
     geom = MultiPolygon([Polygon([(0,0), (0,1), (1,1), (0,1), (1,1), (1,0), (0,0) ])])
     i = model.Images.create(session, footprint_latlon=geom,


### PR DESCRIPTION
Avoids strange errors later on about None type objects not having the required attributes for `from_shape`