### PR TITLE
Adds ability to subpixel a subset of points

### DIFF
--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -367,8 +367,8 @@ def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=251, reduction=11, conver
         dy += (shift_y + dyr)
 
         # Break if the solution has converged
-        size[0] -= reduction
-        size[1] -= reduction
+        size = (size[0] - reduction, size[1] - reduction)
+
         dist = np.linalg.norm([dsample-dx, dline-dy])
         if min(size) < 1:
             return None, None, None

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -304,8 +304,10 @@ def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=251, reduction=11, conver
             A plio geodata object from which the template is extracted
     d_img : object
             A plio geodata object from which the search is extracted
-    size : int
-           One half of the total size of the template, so a 251 default results in a 502 pixel search space
+    size : int, tuple
+           One half of the total size of the template, so a 251 default results in a 502 pixel search space.
+           If an int, the template is square. If a tuple, in the form (x,y), is passed an 
+           irregularly shaped template can be used.
     reduction : int
                 With each recursive call to this func, the size is reduced by this amount
     convergence_threshold : float


### PR DESCRIPTION
This went from ~2500 points ignored to ~440 ignored. I have not visualized, but this PR is about the ability to subset the points.

Code that I used when testing:

```python
# Redefine just in case
from autocnet.matcher.subpixel import cluster_subpixel_register_points
subpixel_template_kwargs = {'image_size':(111,111), 'template_size':(101,101)}

# Now some subset of points are off because of bad initial spice. For these, loosen the criteria on the phase matcher
iterative_phase_kwargs = {'size': 71}  # Try a smaller size so that the point is able to move less. This should help on slivers since we have a better shot to get this area
filters = {'ignore':True} # Filter to only process those points that were ignored in the first phase
cluster_subpixel_register_points(iterative_phase_kwargs=iterative_phase_kwargs,
                                 subpixel_template_kwargs=subpixel_template_kwargs, # Keep the template matcher strict
                                 filters=filters)
```

and then snippet that I was using to check the number of ignored points. (Maybe this would be a nice addition too? - also, don't judge the function name....just hacking around)

```python
from autocnet.io.db.model import Points
from autocnet import Session

def go(filters={}):
    session = Session()
    query = session.query(Points)
    for attr, value in filters.items():
        query = query.filter(getattr(Points, attr)==value)
    res = query.all()
    print(len(res))
    session.close()
go(filters={'ignore':True})
```