### PR TITLE
Changing point projection domain from +/-180 to 0/360

### DIFF
--- a/autocnet/graph/edge.py
+++ b/autocnet/graph/edge.py
@@ -5,7 +5,6 @@ from collections import defaultdict, MutableMapping, Counter
 import numpy as np
 import pandas as pd
 import networkx as nx
-# import pyproj
 from scipy.spatial.distance import cdist
 from shapely.geometry import Point
 import sqlalchemy

--- a/autocnet/graph/edge.py
+++ b/autocnet/graph/edge.py
@@ -975,13 +975,6 @@ class NetworkEdge(Edge):
         session.close()
 
     def get_overlapping_indices(self, kps):
-        # ecef = pyproj.Proj(proj='geocent',
-	# 		               a=self.parent.config['spatial']['semimajor_rad'],
-	# 		               b=self.parent.config['spatial']['semiminor_rad'])
-        # lla = pyproj.Proj(proj='longlat',
-	#		              a=self.parent.config['spatial']['semiminor_rad'],
-	#		              b=self.parent.config['spatial']['semimajor_rad'])
-        # lons, lats, alts = pyproj.transform(ecef, lla, kps.xm.values, kps.ym.values, kps.zm.values)
         lons, lats, alts = reproject([kps.xm.values, kps.ym.values, kps.zm.values], semi_major, semi_minor, 'geocent', 'latlon')
         points = [Point(lons[i], lats[i]) for i in range(len(lons))]
         mask = [i for i in range(len(points)) if self.intersection.contains(points[i])]

--- a/autocnet/graph/edge.py
+++ b/autocnet/graph/edge.py
@@ -976,11 +976,11 @@ class NetworkEdge(Edge):
 
     def get_overlapping_indices(self, kps):
         # ecef = pyproj.Proj(proj='geocent',
-			               a=self.parent.config['spatial']['semimajor_rad'],
-			               b=self.parent.config['spatial']['semiminor_rad'])
+	# 		               a=self.parent.config['spatial']['semimajor_rad'],
+	# 		               b=self.parent.config['spatial']['semiminor_rad'])
         # lla = pyproj.Proj(proj='longlat',
-			              a=self.parent.config['spatial']['semiminor_rad'],
-			              b=self.parent.config['spatial']['semimajor_rad'])
+	#		              a=self.parent.config['spatial']['semiminor_rad'],
+	#		              b=self.parent.config['spatial']['semimajor_rad'])
         # lons, lats, alts = pyproj.transform(ecef, lla, kps.xm.values, kps.ym.values, kps.zm.values)
         lons, lats, alts = reproject([kps.xm.values, kps.ym.values, kps.zm.values], semi_major, semi_minor, 'geocent', 'latlon')
         points = [Point(lons[i], lats[i]) for i in range(len(lons))]

--- a/autocnet/graph/edge.py
+++ b/autocnet/graph/edge.py
@@ -5,7 +5,7 @@ from collections import defaultdict, MutableMapping, Counter
 import numpy as np
 import pandas as pd
 import networkx as nx
-import pyproj
+# import pyproj
 from scipy.spatial.distance import cdist
 from shapely.geometry import Point
 import sqlalchemy
@@ -19,7 +19,7 @@ from autocnet.matcher import subpixel as sp
 from autocnet.matcher import cpu_ring_matcher
 from autocnet.transformation import fundamental_matrix as fm
 from autocnet.transformation import homography as hm
-from autocnet.transformation import spatial
+from autocnet.transformation.spatial import reproject
 from autocnet.vis.graph_view import plot_edge, plot_node, plot_edge_decomposition, plot_matches
 from autocnet.cg import cg
 from autocnet.io.db.model import Images, Keypoints, Matches,\
@@ -239,7 +239,7 @@ class Edge(dict, MutableMapping):
             ic = csmapi.ImageCoord(coords[i][0], coords[i][1])
             ground = camera.imageToGround(ic, 0)
             gnd[i] = [ground.x, ground.y, ground.z]
-        lon, lat, alt = spatial.reproject(gnd.T, semimajor, semiminor,
+        lon, lat, alt = reproject(gnd.T, semimajor, semiminor,
                                     'geocent', 'latlon')
         if srid:
             geoms = []
@@ -975,13 +975,14 @@ class NetworkEdge(Edge):
         session.close()
 
     def get_overlapping_indices(self, kps):
-        ecef = pyproj.Proj(proj='geocent',
+        # ecef = pyproj.Proj(proj='geocent',
 			               a=self.parent.config['spatial']['semimajor_rad'],
 			               b=self.parent.config['spatial']['semiminor_rad'])
-        lla = pyproj.Proj(proj='longlat',
+        # lla = pyproj.Proj(proj='longlat',
 			              a=self.parent.config['spatial']['semiminor_rad'],
 			              b=self.parent.config['spatial']['semimajor_rad'])
-        lons, lats, alts = pyproj.transform(ecef, lla, kps.xm.values, kps.ym.values, kps.zm.values)
+        # lons, lats, alts = pyproj.transform(ecef, lla, kps.xm.values, kps.ym.values, kps.zm.values)
+        lons, lats, alts = reproject([kps.xm.values, kps.ym.values, kps.zm.values], semi_major, semi_minor, 'geocent', 'latlon')
         points = [Point(lons[i], lats[i]) for i in range(len(lons))]
         mask = [i for i in range(len(points)) if self.intersection.contains(points[i])]
         return mask

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -19,9 +19,6 @@ import shapely.wkt as swkt
 import shapely.wkb as swkb
 import shapely.ops
 
-
-# import pyproj
-
 from plio.io.io_controlnetwork import to_isis, from_isis
 from plio.io import io_hdf, io_json
 from plio.utils import utils as io_utils
@@ -1823,8 +1820,6 @@ WHERE
 
     def place_points_from_cnet(self, cnet):
         semi_major, semi_minor = config["spatial"]["semimajor_rad"], config["spatial"]["semiminor_rad"]
-        # ecef = pyproj.Proj(proj='geocent', a=semi_major, b=semi_minor)
-        # lla = pyproj.Proj(proj='latlon', a=semi_major, b=semi_minor)
 
         if isinstance(cnet, str):
             cnet = from_isis(cnet)
@@ -1855,7 +1850,6 @@ WHERE
 
             row = cnetpoint.iloc[0]
             x,y,z= row.adjustedX, row.adjustedY, row.adjustedZ
-            # lon, lat, alt = pyproj.transform(ecef, lla, x, y, z)
             lon, lat, alt = reproject([x, y, z], semi_major, semi_minor, 'geocent', 'latlon')
 
 

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -20,7 +20,7 @@ import shapely.wkb as swkb
 import shapely.ops
 
 
-import pyproj
+# import pyproj
 
 from plio.io.io_controlnetwork import to_isis, from_isis
 from plio.io import io_hdf, io_json
@@ -44,6 +44,7 @@ from autocnet.vis.graph_view import plot_graph, cluster_plot
 from autocnet.control import control
 from autocnet.spatial.overlap import compute_overlaps_sql
 from autocnet.spatial.isis import point_info
+from autocnet.transformation.spatial import reproject
 
 #np.warnings.filterwarnings('ignore')
 
@@ -1822,8 +1823,8 @@ WHERE
 
     def place_points_from_cnet(self, cnet):
         semi_major, semi_minor = config["spatial"]["semimajor_rad"], config["spatial"]["semiminor_rad"]
-        ecef = pyproj.Proj(proj='geocent', a=semi_major, b=semi_minor)
-        lla = pyproj.Proj(proj='latlon', a=semi_major, b=semi_minor)
+        # ecef = pyproj.Proj(proj='geocent', a=semi_major, b=semi_minor)
+        # lla = pyproj.Proj(proj='latlon', a=semi_major, b=semi_minor)
 
         if isinstance(cnet, str):
             cnet = from_isis(cnet)
@@ -1854,7 +1855,9 @@ WHERE
 
             row = cnetpoint.iloc[0]
             x,y,z= row.adjustedX, row.adjustedY, row.adjustedZ
-            lon, lat, alt = pyproj.transform(ecef, lla, x, y, z)
+            # lon, lat, alt = pyproj.transform(ecef, lla, x, y, z)
+            lon, lat, alt = reproject([x, y, z], semi_major, semi_minor, 'geocent', 'latlon')
+
 
             point = Points(identifier=id,
                            ignore=row.pointIgnore,

--- a/autocnet/io/db/tests/test_model.py
+++ b/autocnet/io/db/tests/test_model.py
@@ -127,7 +127,7 @@ def test_create_point(session, data):
     assert p == resp
 
 @pytest.mark.parametrize("data, expected", [
-    ({'pointtype':3, 'adjusted':Point(0,-1000000,0)}, Point(-90, 0)),
+    ({'pointtype':3, 'adjusted':Point(0,-1000000,0)}, Point(270, 0)),
     ({'pointtype':3}, None)
 ])
 def test_create_point_geom(session, data, expected):
@@ -139,7 +139,7 @@ def test_create_point_geom(session, data, expected):
 @pytest.mark.parametrize("data, new_adjusted, expected", [
     ({'pointtype':3, 'adjusted':Point(0,-100000,0)}, None, None),
     ({'pointtype':3, 'adjusted':Point(0,-100000,0)}, Point(0,100000,0), Point(90, 0)),
-    ({'pointtype':3}, Point(0,-100000,0), Point(-90, 0))
+    ({'pointtype':3}, Point(0,-100000,0), Point(270, 0))
 ])
 def test_update_point_geom(session, data, new_adjusted, expected):
     p = model.Points.create(session, **data)

--- a/autocnet/matcher/cross_instrument_matcher.py
+++ b/autocnet/matcher/cross_instrument_matcher.py
@@ -20,7 +20,6 @@ from sqlalchemy.ext.declarative import declarative_base
 import geopandas as gpd
 import plio
 import pvl
-import pyproj
 import pysis
 
 from gdal import ogr

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -171,7 +171,6 @@ def place_points_in_overlap(nodes, geom, cam_type="csm",
             height = dem.read_array(1, [px, py, 1, 1])[0][0]
 
         # Get the BCEF coordinate from the lon, lat
-        # x, y, z = pyproj.transform(lla, ecef, lon, lat, height)
         x, y, z = reproject([lon, lat, height], semi_major, semi_minor,
                             'latlon', 'geocent')
 

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -13,7 +13,7 @@ from autocnet.io.db.model import Images, Measures, Overlay, Points, JsonEncoder
 from autocnet.spatial import isis
 from autocnet.transformation.spatial import reproject
 from plurmy import Slurm
-
+import csmapi
 
 
 # SQL query to decompose pairwise overlaps

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -154,8 +154,6 @@ def place_points_in_overlap(nodes, geom, cam_type="csm",
     points = []
     semi_major = config['spatial']['semimajor_rad']
     semi_minor = config['spatial']['semiminor_rad']
-    # ecef = pyproj.Proj(proj='geocent', a=semi_major, b=semi_minor, lon_wrap=180)
-    # lla = pyproj.Proj(proj='latlon', a=semi_major, b=semi_minor, lon_wrap=180)
     valid = compgeom.distribute_points_in_geom(geom, **distribute_points_kwargs)
     if not valid:
         warnings.warn('Failed to distribute points in overlap')

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -11,9 +11,9 @@ from autocnet import config, dem, Session
 from autocnet.cg import cg as compgeom
 from autocnet.io.db.model import Images, Measures, Overlay, Points, JsonEncoder
 from autocnet.spatial import isis
-
+from autocnet.transformation.spatial import reproject
 from plurmy import Slurm
-import csmapi
+
 
 
 # SQL query to decompose pairwise overlaps
@@ -154,8 +154,8 @@ def place_points_in_overlap(nodes, geom, cam_type="csm",
     points = []
     semi_major = config['spatial']['semimajor_rad']
     semi_minor = config['spatial']['semiminor_rad']
-    ecef = pyproj.Proj(proj='geocent', a=semi_major, b=semi_minor)
-    lla = pyproj.Proj(proj='latlon', a=semi_major, b=semi_minor)
+    # ecef = pyproj.Proj(proj='geocent', a=semi_major, b=semi_minor, lon_wrap=180)
+    # lla = pyproj.Proj(proj='latlon', a=semi_major, b=semi_minor, lon_wrap=180)
     valid = compgeom.distribute_points_in_geom(geom, **distribute_points_kwargs)
     if not valid:
         warnings.warn('Failed to distribute points in overlap')
@@ -173,7 +173,10 @@ def place_points_in_overlap(nodes, geom, cam_type="csm",
             height = dem.read_array(1, [px, py, 1, 1])[0][0]
 
         # Get the BCEF coordinate from the lon, lat
-        x, y, z = pyproj.transform(lla, ecef, lon, lat, height)
+        # x, y, z = pyproj.transform(lla, ecef, lon, lat, height)
+        x, y, z = reproject([lon, lat, height], semi_major, semi_minor,
+                            'latlon', 'geocent')
+
         geom = shapely.geometry.Point(x, y, z)
         point = Points(apriori=geom,
                        adjusted=geom,

--- a/autocnet/transformation/spatial.py
+++ b/autocnet/transformation/spatial.py
@@ -35,8 +35,8 @@ def reproject(record, semi_major, semi_minor, source_proj, dest_proj, **kwargs):
       Transformed coordinates as y, x, z
 
     """
-    source_pyproj = pyproj.Proj(proj = source_proj, a = semi_major, b = semi_minor)
-    dest_pyproj = pyproj.Proj(proj = dest_proj, a = semi_major, b = semi_minor)
+    source_pyproj = pyproj.Proj(proj=source_proj, a=semi_major, b=semi_minor, lon_wrap=180)
+    dest_pyproj = pyproj.Proj(proj=dest_proj, a=semi_major, b=semi_minor, lon_wrap=180)
 
     y, x, z = pyproj.transform(source_pyproj, dest_pyproj, record[0], record[1], record[2], **kwargs)
     return y, x, z


### PR DESCRIPTION
pyproj.Proj class defaults to the -180 to 180 domain. Therefore, when pyproj.transform is called to preform the transformation using those classes the output is in the 180 domain. Instead of chasing down all instances of pyproj and inserting the lon_wrap=180 to set the domain to 360, I consolidated all pyproj calls to instead go through the already implemented reproject() function in autocnet and updated only the pyproj calls within reproject() with the lon_wrap keyword.

This pull request assumes that the images coming in are in the 360 domain!! A method should later be implemented where the projection domain for the points is determined by the domain of the input image (see issue #402 for current discussion on that topic)