### PR TITLE
Accounted for extra output from template matcher

### DIFF
--- a/autocnet/graph/edge.py
+++ b/autocnet/graph/edge.py
@@ -483,7 +483,7 @@ class Edge(dict, MutableMapping):
                     new_y[i] = res[1]
                     strengths[i] = res[2]
             elif method == 'template':
-                new_x[i], new_y[i], strengths[i] = sp.subpixel_template(sx, sy, dx, dy, s_img, d_img,
+                new_x[i], new_y[i], strengths[i], _ = sp.subpixel_template(sx, sy, dx, dy, s_img, d_img,
                                                                      search_size=search_size,
                                                                      template_size=template_size, **kwargs)
 

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -497,7 +497,7 @@ def subpixel_register_point(pointid, iterative_phase_kwargs={}, subpixel_templat
             measure.ignore = True # Unable to phase match
             continue
 
-        new_template_x, new_template_y, template_metric = subpixel_template(source.sample,
+        new_template_x, new_template_y, template_metric, _ = subpixel_template(source.sample,
                                                                 source.line,
                                                                 new_phase_x,
                                                                 new_phase_y,

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -398,7 +398,7 @@ def subpixel_register_measure(measureid, iterative_phase_kwargs={}, subpixel_tem
     res = session.query(Images).filter(Images.id == sourceid).one()
     source_node = NetworkNode(node_id=sourceid, image_path=res.path)
 
-    new_template_x, new_template_y, template_metric = subpixel_template(source.sample,
+    new_template_x, new_template_y, template_metric, _ = subpixel_template(source.sample,
                                                             source.line,
                                                             destination.sample,
                                                             destination.line,


### PR DESCRIPTION
#423 changed subpixel.subpixel_template to also return the correlation map. This just ignores that output where it gets called.