### PR TITLE
Fixes #426

### DIFF
--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -179,7 +179,7 @@ def subpixel_phase(sx, sy, dx, dy,
 
         s_size = s_image.shape
         d_size = d_template.shape
-        updated_size_x = int(min(s_size[1], d_size[1])) # Why is this /2?
+        updated_size_x = int(min(s_size[1], d_size[1]))
         updated_size_y = int(min(s_size[0], d_size[0]))
         
         # Have to subtract 1 from even entries or else the round up that
@@ -326,13 +326,13 @@ def subpixel_ciratefi(sx, sy, dx, dy, s_img, d_img, search_size=251, template_si
                                 size_x=search_size, size_y=search_size)
     template = t_roi.clip()
     search = s_roi.clip()
-    
+
     if template is None or search is None:
         return None, None, None
 
     x_offset, y_offset, strength = ciratefi.ciratefi(template, search, **kwargs)
-    dx += (x_offset + dxr)
-    dy += (y_offset + dyr)
+    dx += (x_offset + t_roi.axr)
+    dy += (y_offset + t_roi.ayr)
     return dx, dy, strength
 
 def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=(251, 251), reduction=11, convergence_threshold=1.0, max_dist=50, **kwargs):

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -11,6 +11,7 @@ from autocnet.matcher.naive_template import pattern_match, pattern_match_autoreg
 from autocnet.matcher import ciratefi
 from autocnet.io.db.model import Measures, Points, Images, JsonEncoder
 from autocnet.graph.node import NetworkNode
+from autocnet.transformation import roi
 
 import geopandas as gpd
 import pandas as pd
@@ -68,12 +69,15 @@ def check_image_size(imagesize):
     imagesize : tuple
                 in the form (size_x, size_y)
     """
-    x = imagesize[0] / 2
-    y = imagesize[1] / 2
+    x = imagesize[0]
+    y = imagesize[1]
+
     if x % 2 == 0:
         x += 1
     if y % 2 == 0:
         y += 1
+    x = floor(x/2)
+    y = floor(y/2)
     return x,y
 
 def clip_roi(img, center_x, center_y, size_x=200, size_y=200):
@@ -133,7 +137,10 @@ def clip_roi(img, center_x, center_y, size_x=200, size_y=200):
             return None, 0, 0
     return subarray, axr, ayr
 
-def subpixel_phase(template, search, **kwargs):
+def subpixel_phase(sx, sy, dx, dy,
+                   s_img, d_img,
+                   image_size=(251, 251),
+                   **kwargs):
     """
     Apply the spectral domain matcher to a search and template image. To
     shift the images, the x_shift and y_shift, need to be subtracted from
@@ -149,7 +156,7 @@ def subpixel_phase(template, search, **kwargs):
     search : ndarray
              The search image
 
-    Returnsslurm-2235260_89.out.2235260_89.out
+    Returns
     -------
     x_offset : float
                Shift in the x-dimension
@@ -160,10 +167,48 @@ def subpixel_phase(template, search, **kwargs):
     strength : tuple
                With the RMSE error and absolute difference in phase
     """
-    if not template.shape == search.shape:
-        raise ValueError('Both the template and search images must be the same shape.')
-    (y_shift, x_shift), error, diffphase = register_translation(search, template, **kwargs)
-    return x_shift, y_shift, (error, diffphase)
+    image_size = check_image_size(image_size)
+    
+    s_roi = roi.Roi(s_img, sx, sy, size_x=image_size[0], size_y=image_size[1])
+    d_roi = roi.Roi(d_img, dx, dy, size_x=image_size[0], size_y=image_size[1])
+
+    s_image = s_roi.clip()
+    d_template = d_roi.clip()
+
+    if s_image.shape != d_template.shape:
+
+        s_size = s_image.shape
+        d_size = d_template.shape
+        updated_size_x = int(min(s_size[1], d_size[1])) # Why is this /2?
+        updated_size_y = int(min(s_size[0], d_size[0]))
+        
+        # Have to subtract 1 from even entries or else the round up that
+        # occurs when the size is split over the midpoint causes the
+        # size to be too large by 1.
+        if updated_size_x % 2 == 0:
+            updated_size_x -= 1
+        if updated_size_y % 2 == 0:
+            updated_size_y -= 1
+
+        # Since the image is smaller than the requested size, set the size to
+        # the current maximum image size and reduce from there on potential
+        # future iterations.
+        size = check_image_size((updated_size_x, updated_size_y))
+        s_roi = roi.Roi(s_img, sx, sy,
+                        size_x=size[0], size_y=size[1])
+        d_roi = roi.Roi(d_img, dx, dy,
+                        size_x=size[0], size_y=size[1])
+        s_image = s_roi.clip()
+        d_template = d_roi.clip()
+
+        if (s_image is None) or (d_template is None):
+            return None, None, None
+    
+    (shift_y, shift_x), error, diffphase = register_translation(s_image, d_template, **kwargs)
+    dx = d_roi.x - shift_x
+    dy = d_roi.y - shift_y
+
+    return dx, dy, (error, diffphase)
 
 def subpixel_template(sx, sy, dx, dy,
                       s_img, d_img,
@@ -223,16 +268,19 @@ def subpixel_template(sx, sy, dx, dy,
     image_size = check_image_size(image_size)
     template_size = check_image_size(template_size)
 
-    s_image, _, _ = clip_roi(s_img, sx, sy, size_x=image_size[0], size_y=image_size[1])
-    d_template, dxr, dyr = clip_roi(d_img, dx, dy, size_x=template_size[0], size_y=template_size[1])
+    s_roi = roi.Roi(s_img, sx, sy, size_x=image_size[0], size_y=image_size[1])
+    d_roi = roi.Roi(d_img, dx, dy, size_x=template_size[0], size_y=template_size[1])
+
+    s_image = s_roi.clip()
+    d_template = d_roi.clip()
 
     if (s_image is None) or (d_template is None):
-        return None, None, None
+        return None, None, None, None
 
     shift_x, shift_y, metrics, corrmap = func(d_template, s_image, **kwargs)
 
-    dx = (dx - shift_x + dxr)
-    dy = (dy - shift_y + dyr)
+    dx = d_roi.x - shift_x
+    dy = d_roi.y - shift_y
 
     return dx, dy, metrics, corrmap
 
@@ -272,10 +320,13 @@ def subpixel_ciratefi(sx, sy, dx, dy, s_img, d_img, search_size=251, template_si
     strength : float
                Strength of the correspondence in the range [-1, 1]
     """
-    template, _, _ = clip_roi(d_img, dx, dy,
+    t_roi = roi.Roi(d_img, dx, dy,
                               size_x=template_size, size_y=template_size)
-    search, dxr, dyr = clip_roi(s_img, sx, sy,
+    s_roi = roi.Roi(s_img, sx, sy,
                                 size_x=search_size, size_y=search_size)
+    template = t_roi.clip()
+    search = s_roi.clip()
+    
     if template is None or search is None:
         return None, None, None
 
@@ -284,7 +335,7 @@ def subpixel_ciratefi(sx, sy, dx, dy, s_img, d_img, search_size=251, template_si
     dy += (y_offset + dyr)
     return dx, dy, strength
 
-def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=251, reduction=11, convergence_threshold=1.0, max_dist=50, **kwargs):
+def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=(251, 251), reduction=11, convergence_threshold=1.0, max_dist=50, **kwargs):
     """
     Iteratively apply a subpixel phase matcher to source (s_img) and destination (d_img)
     images. The size parameter is used to set the initial search space. The algorithm
@@ -307,10 +358,8 @@ def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=251, reduction=11, conver
             A plio geodata object from which the template is extracted
     d_img : object
             A plio geodata object from which the search is extracted
-    size : int, tuple
-           One half of the total size of the template, so a 251 default results in a 502 pixel search space.
-           If an int, the template is square. If a tuple, in the form (x,y), is passed an
-           irregularly shaped template can be used.
+    size : tuple
+           Size of the template in the form (x,y)
     reduction : int
                 With each recursive call to this func, the size is reduced by this amount
     convergence_threshold : float
@@ -334,50 +383,31 @@ def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=251, reduction=11, conver
     # get initial destination location
     dsample = dx
     dline = dy
-    if isinstance(size, int):
-        size = (size, size)
+    
     while True:
-        s_template, _, _ = clip_roi(s_img, sx, sy,
-                                   size_x=size[0], size_y=size[1])
-        d_search, dxr, dyr = clip_roi(d_img, dx, dy,
-                                 size_x=size[0], size_y=size[1])
-
-        if (s_template is None) or (d_search is None):
-            return None, None, None
-        if s_template.shape != d_search.shape:
-            s_size = s_template.shape
-            d_size = d_search.shape
-            updated_size_x = int(min(s_size[1], d_size[1]))  # Why is this /2?
-            updated_size_y = int(min(s_size[0], d_size[0]))
-            # Since the image is smaller than the requested size, set the size to
-            # the current maximum image size and reduce from there on potential
-            # future iterations.
-            size = (updated_size_x, updated_size_y)
-            s_template, _, _ = clip_roi(s_template, sx, sy,
-                                 size_x=size[0], size_y=size[1])
-            d_search, dxr, dyr = clip_roi(d_search, dx, dy,
-                                size_x=size[0], size_y=size[1])
-            if (s_template is None) or (d_search is None):
-                return None, None, None
-
-        # Apply the phase matcher
         try:
-            shift_x, shift_y, metrics = subpixel_phase(s_template, d_search, **kwargs)
+            shifted_dx, shifted_dy, metrics = subpixel_phase(sx, sy, dx, dy, s_img, d_img, image_size=size, **kwargs)
         except:
             return None, None, None
-        # Apply the shift to d_search and compute the new correspondence location
-        dx += shift_x  # The implementation already applies the dxr, dyr shifts
-        dy += shift_y
+
+
+        # Compute the amount of move the matcher introduced
+        delta_dx = abs(shifted_dx - dx)
+        delta_dy = abs(shifted_dy - dy)
+        dx = shifted_dx
+        dy = shifted_dy
+
         # Break if the solution has converged
         size = (size[0] - reduction, size[1] - reduction)
-
         dist = np.linalg.norm([dsample-dx, dline-dy])
+
         if min(size) < 1:
             return None, None, None
-        if abs(shift_x) <= convergence_threshold and\
-           abs(shift_y) <= convergence_threshold and\
+        if delta_dx <= convergence_threshold and\
+           delta_dy<= convergence_threshold and\
            abs(dist) <= max_dist:
-            break
+           break
+        
     return dx, dy, metrics
 
 def subpixel_register_measure(measureid, iterative_phase_kwargs={}, subpixel_template_kwargs={},

--- a/autocnet/matcher/tests/test_ciratefi.py
+++ b/autocnet/matcher/tests/test_ciratefi.py
@@ -7,7 +7,7 @@ from imageio import imread
 from scipy.ndimage.interpolation import rotate
 
 from autocnet.examples import get_path
-from autocnet.matcher import subpixel as sp
+from autocnet.transformation import roi
 from .. import ciratefi
 
 import pytest
@@ -32,7 +32,7 @@ def img_coord():
 @pytest.fixture
 def template(img, img_coord):
     coord_x, coord_y = img_coord
-    template, _, _ = sp.clip_roi(img, coord_x, coord_y, 5, 5)
+    template= roi.Roi(img, coord_x, coord_y, 5, 5).clip()
     template = rotate(template, 90)
     return template
 
@@ -40,7 +40,7 @@ def template(img, img_coord):
 def search():
     coord_x, coord_y = (482.09783936, 652.40679932)
     img = imread(get_path('AS15-M-0298_SML.png'), as_gray=True)
-    search, _, _ = sp.clip_roi(img, coord_x, coord_y, 21, 21)
+    search = roi.Roi(img, coord_x, coord_y, 21, 21).clip()
     return search
 
 @pytest.fixture
@@ -48,7 +48,7 @@ def offset_template(img, img_coord):
     coord_x, coord_y = img_coord
     coord_x += 1
     coord_y += 1
-    offset_template, _, _ = sp.clip_roi(img, coord_x, coord_y, 5, 5)
+    offset_template = roi.Roi(img, coord_x, coord_y, 5, 5).clip()
     return offset_template
 
 def test_cifi_radii_too_large(template, search):

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -203,8 +203,8 @@ def place_points_in_overlap(nodes, geom, cam_type="csm",
 
         # kps are in the image space with upper left origin, so convert to
         # center origin and then convert back into full image space
-        newsample = sample + (interesting.x - size)
-        newline = line + (interesting.y - size)
+        newsample = sample + (interesting.x - image.shape[1])
+        newline = line + (interesting.y - image.shape[0])
 
         # Get the updated lat/lon from the feature in the node
         if cam_type == "isis":

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -206,8 +206,9 @@ def place_points_in_overlap(nodes, geom, cam_type="csm",
         # kps are in the image space with upper left origin and the roi
         # could be the requested size or smaller if near an image boundary.
         # So use the roi upper left_x and top_y for the actual origin.
-        newsample = image_roi.left_x + interesting.x
-        newline = image_roi.top_y + interesting.y
+        left_x, _, top_y, _ = image_roi.image_extent
+        newsample = left_x + interesting.x
+        newline = top_y + interesting.y
 
         # Get the updated lat/lon from the feature in the node
         if cam_type == "isis":

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -12,9 +12,9 @@ from autocnet import config, dem, Session
 from autocnet.cg import cg as compgeom
 from autocnet.io.db.model import Images, Measures, Overlay, Points, JsonEncoder
 from autocnet.spatial import isis
-from autocnet.matcher.subpixel import clip_roi
 from autocnet.matcher.cpu_extractor import extract_most_interesting
 from autocnet.transformation.spatial import reproject
+from autocnet.transformation import roi
 
 from plurmy import Slurm
 import csmapi
@@ -163,6 +163,7 @@ def place_points_in_overlap(nodes, geom, cam_type="csm",
     points = []
     semi_major = config['spatial']['semimajor_rad']
     semi_minor = config['spatial']['semiminor_rad']
+
     valid = compgeom.distribute_points_in_geom(geom, **distribute_points_kwargs)
     if not valid:
         warnings.warn('Failed to distribute points in overlap')
@@ -194,17 +195,19 @@ def place_points_in_overlap(nodes, geom, cam_type="csm",
             sample, line = image_coord.samp, image_coord.line
 
         # Extract ORB features in a sub-image around the desired point
-        image, _, _ = clip_roi(node.geodata, sample, line, size_x=size, size_y=size)
+        image_roi = roi.Roi(node.geodata, sample, line, size_x=size, size_y=size)
+        image = image_roi.clip()
         try:
             interesting = extract_most_interesting(image)
         except:
             warnings.warn('Could not find an interesting feature around point')
             continue
-
-        # kps are in the image space with upper left origin, so convert to
-        # center origin and then convert back into full image space
-        newsample = sample + (interesting.x - image.shape[1])
-        newline = line + (interesting.y - image.shape[0])
+    
+        # kps are in the image space with upper left origin and the roi
+        # could be the requested size or smaller if near an image boundary.
+        # So use the roi upper left_x and top_y for the actual origin.
+        newsample = image_roi.left_x + interesting.x
+        newline = image_roi.top_y + interesting.y
 
         # Get the updated lat/lon from the feature in the node
         if cam_type == "isis":

--- a/autocnet/spatial/tests/test_overlap_points.py
+++ b/autocnet/spatial/tests/test_overlap_points.py
@@ -9,36 +9,39 @@ from autocnet.graph.node import Node
 import csmapi
 
 MockKeypoints = namedtuple('Keypoints', ['x', 'y'])
-mockkeypoints = MockKeypoints(0,0)
+mockkeypoints = MockKeypoints(5,5)
 
 @patch('autocnet.cg.cg.distribute_points_in_geom', return_value=[(0, 0), (5, 5), (10, 10)])
-@patch('autocnet.spatial.overlap.clip_roi', return_value=[np.zeros((3,3)), None, None])
 @patch('autocnet.spatial.overlap.extract_most_interesting', return_value=mockkeypoints)
-def test_place_points_in_overlap(point_distributer, clip_roi, extractor):
+def test_place_points_in_overlap(point_distributer, extractor):
     # Mock setup
     first_node = MagicMock()
     first_node.camera = MagicMock()
     first_node.camera.groundToImage.return_value = csmapi.ImageCoord(1.0, 0.0)
     first_node.camera.imageToGround.return_value = csmapi.EcefCoord(1.0,1.0,1.0)
     first_node.isis_serial = '1'
+    first_node.geodata = np.zeros((100,100))
     first_node.__getitem__.return_value = 1
     second_node = MagicMock()
     second_node.camera = MagicMock()
     second_node.camera.groundToImage.return_value = csmapi.ImageCoord(1.0, 1.0)
     second_node.camera.imagetoground.return_value = csmapi.EcefCoord(1.0,1.0,1.0)
     second_node.isis_serial = '2'
+    second_node.geodata = np.zeros((100,100))
     second_node.__getitem__.return_value = 2
     third_node = MagicMock()
     third_node.camera = MagicMock()
     third_node.camera.groundToImage.return_value = csmapi.ImageCoord(0.0, 1.0)
     third_node.camera.imageToGround.return_value = csmapi.EcefCoord(1.0,1.0,1.0)
     third_node.isis_serial = '3'
+    third_node.geodata = np.zeros((100,100))
     third_node.__getitem__.return_value = 3
     fourth_node = MagicMock()
     fourth_node.camera = MagicMock()
     fourth_node.camera.groundToImage.return_value = csmapi.ImageCoord(0.0, 0.0)
     first_node.camera.imageToGround.return_value = csmapi.EcefCoord(1.0,0,1.0)
     fourth_node.isis_serial = '4'
+    fourth_node.geodata = np.zeros((100,100))
     fourth_node.__getitem__.return_value = 4
 
     # Actual function being tested
@@ -54,8 +57,7 @@ def test_place_points_in_overlap(point_distributer, clip_roi, extractor):
         assert measure_ids == [1, 2, 3, 4]
         assert measure_serials == ['1', '2', '3', '4']
 
-    # Check the mocks
-    np.testing.assert_array_equal(point_distributer.call_args[0][0], np.zeros((3,3)))
+    # Check the mocks  
     first_node.camera.groundToImage.assert_called()
     second_node.camera.groundToImage.assert_called()
     third_node.camera.groundToImage.assert_called()

--- a/autocnet/transformation/roi.py
+++ b/autocnet/transformation/roi.py
@@ -1,0 +1,151 @@
+from math import modf, floor
+import numpy as np
+
+
+class Roi():
+    """
+    Region of interest (ROI) object that is a sub-image taken from
+    a larger image or array. This object supports transformations
+    between the image coordinate space and the ROI coordinate
+    space.
+
+    Attributes
+    ----------
+
+    x : float
+        The x coordinate in image space
+
+    y : float
+        The y coordinate in image space
+
+    size_x : int
+             1/2 the total ROI width in pixels
+
+    size_y : int
+             1/2 the total ROI height in pixels
+
+    origin_roi : tuple
+                 in the form (x,y). The origin coordinates
+                 of the ROI (center of the ROI)
+
+    left_x : int
+             The left pixel coordinate in image space
+
+    right_x : int
+              The right pixel coordinage in image space
+
+    top_y : int
+            The top image coordinate in image space
+
+    bottom_y : int
+               The bottom image coordinate in imge space
+    """
+    def __init__(self, geodataset, x, y, size_x=200, size_y=200):
+        self.geodataset = geodataset
+
+        self.x = x
+        self.y = y
+        self.size_x = size_x
+        self.size_y = size_y
+        
+    @property
+    def x(self):
+        return self._x + self.axr
+
+    @x.setter
+    def x(self, x):
+        self.axr, self._x = modf(x)
+    
+    @property
+    def y(self):
+        return self._y + self.ayr
+
+    @y.setter
+    def y(self, y):
+        self.ayr, self._y = modf(y)
+
+    @property
+    def left_x(self):
+        return self._left_x
+
+    @left_x.setter
+    def left_x(self, x):
+        self._left_x = int(x)
+
+    @property
+    def right_x(self):
+        return self._right_x
+
+    @right_x.setter
+    def right_x(self, x):
+        self._right_x = int(x)
+
+    @property
+    def top_y(self):
+        return self._top_y
+    
+    @top_y.setter
+    def top_y(self, y):
+        self._top_y = int(y)
+
+    @property
+    def bottom_y(self):
+        return self._bottom_y
+
+    @bottom_y.setter
+    def bottom_y(self, y):
+        self._bottom_y = int(y)
+
+    @property
+    def origin_roi(self):
+        _ = self.image_extent
+        return ((self.right_x - self.left_x) / 2,
+                (self.bottom_y - self.top_y) / 2)
+
+    @property
+    def image_extent(self):
+        """
+        In full image space, this method computes the valid
+        pixel indices that can be extracted.
+        """
+        try:
+            # Geodataset object
+            raster_size = self.geodataset.raster_size
+        except:
+            # Numpy array in y,x form
+            raster_size = self.geodataset.shape[::-1]
+
+        # what is the extent that can actually be extracted?
+        self.left_x = self._x - self.size_x
+        self.right_x = self._x + self.size_x
+        self.top_y = self._y - self.size_y
+        self.bottom_y = self.y + self.size_y
+
+        if self._x - self.size_x < 0:
+            self.left_x = 0
+        if self._y - self.size_y < 0:
+            self.top_y = 0
+        if self._x + self.size_x > raster_size[0]:
+            self.right_x = raster_size[0]
+        if self._y + self.size_y > raster_size[1]:
+            self.bottom_y = raster_size[1]
+
+        return [self.left_x, self.right_x,
+                self.top_y, self.bottom_y]
+
+    def clip(self):
+        pixels = self.image_extent
+        if isinstance(self.geodataset, np.ndarray):
+            self.array = self.geodataset[pixels[2]:pixels[3], 
+                                         pixels[0]:pixels[1]]
+        else:
+            # Have to reformat to [xstart, ystart, xnumberpixels, ynumberpixels]
+            pixels = [pixels[0], pixels[2], pixels[1]-pixels[0], pixels[3]-pixels[2]]
+            self.array = self.geodataset.read_array(pixels=pixels)
+
+    def transform(self, x, y):
+        """
+        Convert arbitrary coordinates from the ROI coordinate system
+        to the full image coordinate system.
+        """
+        pass

--- a/autocnet/transformation/roi.py
+++ b/autocnet/transformation/roi.py
@@ -24,10 +24,6 @@ class Roi():
     size_y : int
              1/2 the total ROI height in pixels
 
-    origin_roi : tuple
-                 in the form (x,y). The origin coordinates
-                 of the ROI (center of the ROI)
-
     left_x : int
              The left pixel coordinate in image space
 
@@ -65,44 +61,6 @@ class Roi():
         self.ayr, self._y = modf(y)
 
     @property
-    def left_x(self):
-        return self._left_x
-
-    @left_x.setter
-    def left_x(self, x):
-        self._left_x = int(x)
-
-    @property
-    def right_x(self):
-        return self._right_x
-
-    @right_x.setter
-    def right_x(self, x):
-        self._right_x = int(x)
-
-    @property
-    def top_y(self):
-        return self._top_y
-    
-    @top_y.setter
-    def top_y(self, y):
-        self._top_y = int(y)
-
-    @property
-    def bottom_y(self):
-        return self._bottom_y
-
-    @bottom_y.setter
-    def bottom_y(self, y):
-        self._bottom_y = int(y)
-
-    @property
-    def origin_roi(self):
-        _ = self.image_extent
-        return ((self.right_x - self.left_x) / 2,
-                (self.bottom_y - self.top_y) / 2)
-
-    @property
     def image_extent(self):
         """
         In full image space, this method computes the valid
@@ -116,22 +74,21 @@ class Roi():
             raster_size = self.geodataset.shape[::-1]
 
         # what is the extent that can actually be extracted?
-        self.left_x = self._x - self.size_x
-        self.right_x = self._x + self.size_x
-        self.top_y = self._y - self.size_y
-        self.bottom_y = self.y + self.size_y
+        left_x = self._x - self.size_x
+        right_x = self._x + self.size_x
+        top_y = self._y - self.size_y
+        bottom_y = self.y + self.size_y
 
         if self._x - self.size_x < 0:
-            self.left_x = 0
+            left_x = 0
         if self._y - self.size_y < 0:
-            self.top_y = 0
+            top_y = 0
         if self._x + self.size_x > raster_size[0]:
-            self.right_x = raster_size[0]
+            right_x = raster_size[0]
         if self._y + self.size_y > raster_size[1]:
-            self.bottom_y = raster_size[1]
+            bottom_y = raster_size[1]
 
-        return [self.left_x, self.right_x,
-                self.top_y, self.bottom_y]
+        return list(map(int, [left_x, right_x, top_y, bottom_y]))
 
     def clip(self):
         pixels = self.image_extent

--- a/autocnet/transformation/roi.py
+++ b/autocnet/transformation/roi.py
@@ -136,12 +136,14 @@ class Roi():
     def clip(self):
         pixels = self.image_extent
         if isinstance(self.geodataset, np.ndarray):
-            self.array = self.geodataset[pixels[2]:pixels[3], 
-                                         pixels[0]:pixels[1]]
+            array = self.geodataset[pixels[2]:pixels[3]+1, 
+                                         pixels[0]:pixels[1]+1]
         else:
             # Have to reformat to [xstart, ystart, xnumberpixels, ynumberpixels]
             pixels = [pixels[0], pixels[2], pixels[1]-pixels[0], pixels[3]-pixels[2]]
-            self.array = self.geodataset.read_array(pixels=pixels)
+            array = self.geodataset.read_array(pixels=pixels)
+
+        return array
 
     def transform(self, x, y):
         """

--- a/autocnet/transformation/tests/test_roi.py
+++ b/autocnet/transformation/tests/test_roi.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+
+from autocnet.transformation.roi import Roi
+
+@pytest.mark.parametrize("x, y, axr, ayr",[
+                         (10.1, 10.1, .1, .1),
+                         (10.5, 10.5, .5, .5),
+                         (10.9, 10.9, .9, .9)
+    ])
+def test_roi_remainder(x, y, axr, ayr):
+    gd = np.zeros((10,10))
+    roi = Roi(gd, x, y)
+    pytest.approx(roi.axr, axr)
+    pytest.approx(roi.ayr, ayr)
+    assert roi.x == x
+    assert roi.y == y
+
+@pytest.mark.parametrize("x, y, size_arr, size_roi, expected",[
+    (50, 50, (100,100), (10,10), [40,60,40,60]),
+    (10, 10, (100, 100), (20, 20), [0, 30, 0, 30]),
+    (75, 75, (100,100), (30,30), [45, 100, 45, 100])
+])
+def test_extent_computation(x, y, size_arr, size_roi, expected):
+    gd = np.zeros(size_arr)
+    roi = Roi(gd, x, y, size_x=size_roi[0], size_y=size_roi[1])
+    pixels = roi.image_extent
+    assert pixels == expected
+
+@pytest.mark.parametrize("x, y, size_arr, size_roi, expected",[
+    (50, 50, (100,100), (10,10), (4040, 5959)),
+    (10, 10, (100, 100), (20, 20), (0,2929)),
+    (75, 75, (100,100), (30,30), (4545, 9999))
+])
+def test_array_extent_computation(x, y, size_arr, size_roi, expected):
+    gd = np.arange(size_arr[0]*size_arr[1]).reshape(size_arr)
+    roi = Roi(gd, x, y, size_x=size_roi[0], size_y=size_roi[1])
+    roi.clip()
+    assert roi.array.min() == expected[0]
+    assert roi.array.max() == expected[1]
+
+@pytest.mark.parametrize("x, y, size_arr, size_roi, expected",[
+    (50, 50, (100,100), (10,10), (10, 10)),
+    (10, 10, (100, 100), (20, 20), (15,15)),
+    (75, 75, (100,100), (30,30), (27.5, 27.5 ))
+])
+def test_roi_origin(x, y, size_arr, size_roi, expected):
+    gd = np.zeros(size_arr)
+    roi = Roi(gd, x, y, size_x=size_roi[0], size_y=size_roi[1])
+    pixels = roi.image_extent
+    assert roi.origin_roi == expected
+
+@pytest.mark.parametrize("x, y, x1, y1, xs, ys, size_arr, size_roi, expected",[
+    (50, 50, 50, 50, -5, -5, (100, 100), (10, 10), (45, 45)),
+    (50, 50, 10, 10, -5, -5, (100, 100), (20, 20), (5,  5 )),
+
+])
+def test_subpixel_using_roi(x, y, x1, y1, xs, ys, size_arr, size_roi, expected):
+    source = np.arange(size_arr[0]*size_arr[1]).reshape(size_arr)
+    destination = np.arange(size_arr[0]*size_arr[1]).reshape(size_arr)
+    s_roi = Roi(source, x, y, size_x=size_roi[0], size_y=size_roi[1])
+    d_roi = Roi(destination, x1, y1, size_x=size_roi[0], size_y=size_roi[1])
+
+    # Then subpixel matching happens on the two ROIs
+    x_shift = xs
+    y_shift = ys    
+
+    new_d_x = d_roi.x + x_shift
+    new_d_y = d_roi.y + y_shift
+
+    assert new_d_x == expected[0]
+    assert new_d_y == expected[1]

--- a/autocnet/transformation/tests/test_roi.py
+++ b/autocnet/transformation/tests/test_roi.py
@@ -28,16 +28,16 @@ def test_extent_computation(x, y, size_arr, size_roi, expected):
     assert pixels == expected
 
 @pytest.mark.parametrize("x, y, size_arr, size_roi, expected",[
-    (50, 50, (100,100), (10,10), (4040, 5959)),
-    (10, 10, (100, 100), (20, 20), (0,2929)),
+    (50, 50, (100,100), (10,10), (4040, 6060)),
+    (10, 10, (100, 100), (20, 20), (0,3030)),
     (75, 75, (100,100), (30,30), (4545, 9999))
 ])
 def test_array_extent_computation(x, y, size_arr, size_roi, expected):
     gd = np.arange(size_arr[0]*size_arr[1]).reshape(size_arr)
     roi = Roi(gd, x, y, size_x=size_roi[0], size_y=size_roi[1])
-    roi.clip()
-    assert roi.array.min() == expected[0]
-    assert roi.array.max() == expected[1]
+    array = roi.clip()
+    assert array.min() == expected[0]
+    assert array.max() == expected[1]
 
 @pytest.mark.parametrize("x, y, size_arr, size_roi, expected",[
     (50, 50, (100,100), (10,10), (10, 10)),
@@ -53,7 +53,7 @@ def test_roi_origin(x, y, size_arr, size_roi, expected):
 @pytest.mark.parametrize("x, y, x1, y1, xs, ys, size_arr, size_roi, expected",[
     (50, 50, 50, 50, -5, -5, (100, 100), (10, 10), (45, 45)),
     (50, 50, 10, 10, -5, -5, (100, 100), (20, 20), (5,  5 )),
-
+    (50, 50, 10, 10,  5,  5, (100, 100), (20, 20), (15, 15 ))
 ])
 def test_subpixel_using_roi(x, y, x1, y1, xs, ys, size_arr, size_roi, expected):
     source = np.arange(size_arr[0]*size_arr[1]).reshape(size_arr)

--- a/autocnet/transformation/tests/test_roi.py
+++ b/autocnet/transformation/tests/test_roi.py
@@ -39,17 +39,6 @@ def test_array_extent_computation(x, y, size_arr, size_roi, expected):
     assert array.min() == expected[0]
     assert array.max() == expected[1]
 
-@pytest.mark.parametrize("x, y, size_arr, size_roi, expected",[
-    (50, 50, (100,100), (10,10), (10, 10)),
-    (10, 10, (100, 100), (20, 20), (15,15)),
-    (75, 75, (100,100), (30,30), (27.5, 27.5 ))
-])
-def test_roi_origin(x, y, size_arr, size_roi, expected):
-    gd = np.zeros(size_arr)
-    roi = Roi(gd, x, y, size_x=size_roi[0], size_y=size_roi[1])
-    pixels = roi.image_extent
-    assert roi.origin_roi == expected
-
 @pytest.mark.parametrize("x, y, x1, y1, xs, ys, size_arr, size_roi, expected",[
     (50, 50, 50, 50, -5, -5, (100, 100), (10, 10), (45, 45)),
     (50, 50, 10, 10, -5, -5, (100, 100), (20, 20), (5,  5 )),


### PR DESCRIPTION
See #426 for the related issue.

- Test updates to the subpixel_template, subpixel_phase, iterative_phase, and place_points_in_overlaps methods that make me much more comfortable that the code is behaving how we believe it is.
- Added an ROI object to (1) store the offsets that we need in subpixel shifting and overlap computation, (2) to make the returns cleaners, (3) to provide a place to implement warping, and (4) to, I think, make this more testable.