### PR TITLE
Switching order of point registration

### DIFF
--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -220,9 +220,6 @@ def subpixel_template(sx, sy, dx, dy,
     autocnet.matcher.naive_template.pattern_match_autoreg : for the jwargs that can be passed to the autoreg style matcher
     """
 
-    print(f'subpixel template image size ={image_size}')
-    print(f'subpixel template template size ={template_size}')
-
     image_size = check_image_size(image_size)
     template_size = check_image_size(template_size)
 
@@ -339,7 +336,6 @@ def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=251, reduction=11, conver
     dline = dy
     if isinstance(size, int):
         size = (size, size)
-        print(f'iterative phase size = {size}')
     while True:
         s_template, _, _ = clip_roi(s_img, sx, sy,
                                    size_x=size[0], size_y=size[1])

--- a/bin/acn_overlaps
+++ b/bin/acn_overlaps
@@ -30,6 +30,8 @@ def main(msg, config):
     if overlap is None:
         print('Could not find overlap with ID', id)
         sys.exit(1)
+    
+    print('Placing points in overlap', oid)
     geom = overlap.geom
     nodes = []
     for id in overlap.intersections:
@@ -37,8 +39,7 @@ def main(msg, config):
         nodes.append(NetworkNode(node_id=id, image_path=res.path))
     session.close()
 
-    print('Placing points in overlap', oid)
-    points = place_points_in_overlap(nodes, geom, msg["cam_type"],
+    points = place_points_in_overlap(nodes, geom, cam_type=msg["cam_type"],
                                      distribute_points_kwargs=msg['distribute_points_kwargs'])
 
     print('Adding {} points to the database.'.format(len(points)))


### PR DESCRIPTION
As per previous group discussion, phase template matching works best on small areas. So I am switching the order under the assumption that naive template matching will get the registration close (or fail and then be ignored) and the phase template can do a final adjustment on a much smaller area.