### PR TITLE
Explicit pointid, remove catch all try/excepts, adding isis point projection error handling

### DIFF
--- a/autocnet/io/db/model.py
+++ b/autocnet/io/db/model.py
@@ -271,9 +271,10 @@ class PointType(enum.IntEnum):
 
 class Points(BaseMixin, Base):
     __tablename__ = 'points'
-    id = Column(Integer, primary_key=True, autoincrement=False)
+    id = Column(Integer, primary_key=True, autoincrement=True)
     _pointtype = Column("pointType", IntEnum(PointType), nullable=False)  # 2, 3, 4 - Could be an enum in the future, map str to int in a decorator
     identifier = Column(String, unique=True)
+    overlapid = Column(Integer, ForeignKey('overlay.id'), nullable=False)
     _geom = Column("geom", Geometry('POINT', srid=latitudinal_srid, dimension=2, spatial_index=True))
     cam_type = Column(String)
     ignore = Column("pointIgnore", Boolean, default=False)

--- a/autocnet/io/db/model.py
+++ b/autocnet/io/db/model.py
@@ -274,7 +274,7 @@ class Points(BaseMixin, Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     _pointtype = Column("pointType", IntEnum(PointType), nullable=False)  # 2, 3, 4 - Could be an enum in the future, map str to int in a decorator
     identifier = Column(String, unique=True)
-    overlapid = Column(Integer, ForeignKey('overlay.id'), nullable=False)
+    overlapid = Column(Integer, ForeignKey('overlay.id'))
     _geom = Column("geom", Geometry('POINT', srid=latitudinal_srid, dimension=2, spatial_index=True))
     cam_type = Column(String)
     ignore = Column("pointIgnore", Boolean, default=False)

--- a/autocnet/io/db/model.py
+++ b/autocnet/io/db/model.py
@@ -271,7 +271,7 @@ class PointType(enum.IntEnum):
 
 class Points(BaseMixin, Base):
     __tablename__ = 'points'
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id = Column(Integer, primary_key=True, autoincrement=False)
     _pointtype = Column("pointType", IntEnum(PointType), nullable=False)  # 2, 3, 4 - Could be an enum in the future, map str to int in a decorator
     identifier = Column(String, unique=True)
     _geom = Column("geom", Geometry('POINT', srid=latitudinal_srid, dimension=2, spatial_index=True))

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -671,7 +671,7 @@ def subpixel_register_point(pointid, iterative_phase_kwargs={}, subpixel_templat
             continue
 
         # Update the measure
-        if new_template_x:
+        if new_x:
             measure.sample = new_x
             measure.line = new_y
             measure.weight = cost

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -27,8 +27,6 @@ import pandas as pd
 
 import pvl
 
-import logging
-
 # TODO: look into KeyPoint.size and perhaps use to determine an appropriately-sized search/template.
 def _prep_subpixel(nmatches, nstrengths=2):
     """
@@ -472,13 +470,6 @@ def geom_match(base_cube, input_cube, bcenter_x, bcenter_y, size_x=60, size_y=60
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {input_cube.base_name}')
                 return None, None, None, None, None
 
-    # do we need this check anymore? Process Error + try/except should not allow projection outside
-    # of cubes
-    # input_cube_extents = input_cube.raster_size
-    # for x,y in cube_points:
-    #     if x < 0 or y < 0 or x > input_cube_extents[0] or y > input_cube_extents[1]:
-    #         return None, None, None, None, None
-
     base_gcps = np.array([*match_points])
     base_gcps[:,0] -= base_startx
     base_gcps[:,1] -= base_starty
@@ -524,13 +515,10 @@ def geom_match(base_cube, input_cube, bcenter_x, bcenter_y, size_x=60, size_y=60
     # These parameters seem to work best, should pass as kwargs later
     restemplate = subpixel_template(size_x, size_y, size_x, size_y, bytescale(base_arr), bytescale(dst_arr), **template_kwargs)
 
-    print('subpixel_template return: ', restemplate[0], restemplate[1], restemplate[2])
-
     if phase_kwargs:
         resphase = iterative_phase(size_x, size_y, restemplate[0], restemplate[1], base_arr, dst_arr, **phase_kwargs)
         _,_,maxcorr, corrmap = restemplate
         x,y,_ = resphase
-        print('iterative_phase return: ', resphase[0], resphase[1], resphase[2])
     else:
         x,y,maxcorr,corrmap = restemplate
 
@@ -538,8 +526,6 @@ def geom_match(base_cube, input_cube, bcenter_x, bcenter_y, size_x=60, size_y=60
         return None, None, None, None, None
 
     sample, line = affine([x,y])[0]
-    print(f'x = {x}, y = {y}')
-    print(f'sample = {sample}, line = {line}')
     sample += start_x
     line += start_y
 
@@ -679,8 +665,6 @@ def subpixel_register_point(pointid, iterative_phase_kwargs={}, subpixel_templat
             continue
 
         cost = cost_func(dist, template_metric)
-        print(f'dist = {dist}, template_metric = {template_metric}')
-        print(f'cost = {cost}, threshold = {threshold}')
 
         if cost <= threshold:
             measure.ignore = True # Threshold criteria not met
@@ -697,7 +681,7 @@ def subpixel_register_point(pointid, iterative_phase_kwargs={}, subpixel_templat
         measure.ignore = False
         source.ignore = False
 
-    #session.commit()
+    session.commit()
     session.close()
 
 def subpixel_register_points(iterative_phase_kwargs={'size': 251},

--- a/bin/acn_overlaps
+++ b/bin/acn_overlaps
@@ -38,8 +38,11 @@ def main(msg, config):
         res = session.query(Images).filter(Images.id == id).one()
         nodes.append(NetworkNode(node_id=id, image_path=res.path))
     session.close()
-
-    points = place_points_in_overlap(nodes, geom, cam_type=msg["cam_type"],
+    
+    q = "SELECT MAX(id) FROM overlay"
+    oid_max = session.execute(q).first()[0]
+    oid = str(oid).rjust(len(str(oid_max)), '0')
+    points = place_points_in_overlap(oid, nodes, geom, cam_type=msg["cam_type"],
                                      distribute_points_kwargs=msg['distribute_points_kwargs'])
 
     print('Adding {} points to the database.'.format(len(points)))

--- a/bin/acn_overlaps
+++ b/bin/acn_overlaps
@@ -39,9 +39,6 @@ def main(msg, config):
         nodes.append(NetworkNode(node_id=id, image_path=res.path))
     session.close()
     
-    q = "SELECT MAX(id) FROM overlay"
-    oid_max = session.execute(q).first()[0]
-    oid = str(oid).rjust(len(str(oid_max)), '0')
     points = place_points_in_overlap(oid, nodes, geom, cam_type=msg["cam_type"],
                                      distribute_points_kwargs=msg['distribute_points_kwargs'])
 


### PR DESCRIPTION
Contains a lot of small alterations:
- specifying pointid and outputing to subpixel logs, for easier debugging
- lowering the default size of iterative phase
- removing the catch all try excepts in matcher/subpixel.py
- raising errors in spatial/isis.py when point does not properly project to/from ground (exposing error keyword output by isis campt)
