### PR TITLE
Fixes 376 and uses non-default PW for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ We suggest using Anaconda Python to install Autocnet within a virtual environmen
 ## How to run the test suite locally
 
 1. Install Docker
-2. Get the Postgresql with Postgis container and run it `docker run --name testdb -e POSTGRES_PASSOWRD='' -e POSTGRES_USER='postgres' -p 5432:5432 -d mdillon/postgis`
+2. Get the Postgresql with Postgis container and run it `docker run --name testdb -e POSTGRES_PASSOWRD='NotTheDefault' -e POSTGRES_USER='postgres' -p 5432:5432 -d mdillon/postgis`
 3. create database template_postgis: `docker exec testdb psql -c 'create database template_postgis;' -U postgres`
-4. Run the test suite: `autocnet_config=config/test_config.yml pytest autocnet`
+4. Run the test suite: `pytest autocnet`

--- a/conftest.py
+++ b/conftest.py
@@ -88,9 +88,9 @@ def default_configuration():
                   'semiminor_rad': 3376200,
                   'proj4_str': '+proj:longlat +a:3396190 +b:3376200 +no_defs',
                   'dem': None}}
-     if os.environ.get('TRAVIS', False):
-         config['database']['password'] = ''
-     return config
+    if os.environ.get('TRAVIS', False):
+        config['database']['password'] = ''
+    return config
 
 @pytest.fixture()
 def ncg(default_configuration):

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import Mock, MagicMock
 
 import networkx as nx
@@ -67,7 +68,7 @@ def default_configuration():
               'processing_memory': 8192},
               'database': {'type': 'postgresql',
                   'username': 'postgres',
-                  'password': '',
+                  'password': 'NotTheDefault',
                   'host': 'localhost',
                   'port': 5432,
                   'pgbouncer_port': 5432,
@@ -87,7 +88,9 @@ def default_configuration():
                   'semiminor_rad': 3376200,
                   'proj4_str': '+proj:longlat +a:3396190 +b:3376200 +no_defs',
                   'dem': None}}
-    return config
+     if os.environ.get('TRAVIS', False):
+         config['database']['password'] = ''
+     return config
 
 @pytest.fixture()
 def ncg(default_configuration):


### PR DESCRIPTION
The PW for local testing is now 'NotTheDefault'. This should fix #376. The README has been updated. The conftest.py file now looks for the 'TRAVIS' env variable since travis defaults to a blank password (and it is way easier to add this check in our code base than to figure out what Travis will do with a PW change on the postgres user...)