### PR TITLE
Adds support for apply with query and overlay points

### DIFF
--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -1558,6 +1558,40 @@ class NetworkCandidateGraph(CandidateGraph):
 
         walltime : str
                    in the format Hour:Minute:Second, 00:00:00
+
+        chunksize : int
+                    The maximum number of jobs to submit per job array. Defaults to 1000.
+                    This number may be have an actualy higher or lower limited based on 
+                    how the cluster has been configured.
+        
+        filters : dict
+                  Of simple filters to apply on database rows where the key is the attribute and
+                  the value is a boolean. This is usable only when applying to measures, points, or overlays.
+
+        query_string : str
+                       A SQL query to be applied to the iterable. This is usable only when applying to measures, points, or overlays.
+
+        kwargs : dict
+                 Of keyword arguments passed to the function being applied
+
+        Examples
+        --------
+        Apply a function to the overlay table omitting those overlay rows that already have 
+        points within them and have an area less than a given threshold.
+
+        >>> query_string = 'SELECT overlay.id FROM overlay LEFT JOIN points ON ST_INTERSECTS(overlay.geom, points.geom) WHERE points.id IS NULL AND ST_AREA(overlay.geom) >= 0.0001;'
+        >>> njobs = ncg.apply('spatial.overlap.place_points_in_overlap', on='overlaps', query_string=query_string)
+
+        Apply a function to the overlay table and pass keyword arguments (kwargs) to the function.
+
+        >>> def ns(x):
+                from math import ceil
+                return ceil(round(x,1)*8)
+        >>> def ew(x):
+                from math import ceil
+                return ceil(round(x,1)*2)
+        >>> distribute_points_kwargs = {'nspts_func':ns, 'ewpts_func':ew, 'method':'classic'}
+        >>> njobs = ncg.apply('spatial.overlap.place_points_in_overlap', on='overlaps', distribute_points_kwargs=distribute_points_kwargs)
         """
 
         # Determine which obj will be called

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -1566,10 +1566,16 @@ class NetworkCandidateGraph(CandidateGraph):
         
         filters : dict
                   Of simple filters to apply on database rows where the key is the attribute and
-                  the value is a boolean. This is usable only when applying to measures, points, or overlays.
+                  the value used to check equivalency (e.g., attribute == value). 
+                  This is usable only when applying to measures, points, or overlays.
+                  Filters can not be used with a query_string. Filters are included as a convenience 
+                  and are really only usable for simple equivalency checks.
 
         query_string : str
-                       A SQL query to be applied to the iterable. This is usable only when applying to measures, points, or overlays.
+                       A SQL query to be applied to the iterable.
+                       This is usable only when applying to measures, points, or overlays.
+                       The query_string can not be used with a filter and is appropriate for
+                       any queries. 
 
         kwargs : dict
                  Of keyword arguments passed to the function being applied
@@ -1579,7 +1585,9 @@ class NetworkCandidateGraph(CandidateGraph):
         Apply a function to the overlay table omitting those overlay rows that already have 
         points within them and have an area less than a given threshold.
 
-        >>> query_string = 'SELECT overlay.id FROM overlay LEFT JOIN points ON ST_INTERSECTS(overlay.geom, points.geom) WHERE points.id IS NULL AND ST_AREA(overlay.geom) >= 0.0001;'
+        >>> query_string = 'SELECT overlay.id FROM overlay LEFT JOIN\
+            points ON ST_INTERSECTS(overlay.geom, points.geom) WHERE\
+                points.id IS NULL AND ST_AREA(overlay.geom) >= 0.0001;'
         >>> njobs = ncg.apply('spatial.overlap.place_points_in_overlap', on='overlaps', query_string=query_string)
 
         Apply a function to the overlay table and pass keyword arguments (kwargs) to the function.
@@ -1591,7 +1599,8 @@ class NetworkCandidateGraph(CandidateGraph):
                 from math import ceil
                 return ceil(round(x,1)*2)
         >>> distribute_points_kwargs = {'nspts_func':ns, 'ewpts_func':ew, 'method':'classic'}
-        >>> njobs = ncg.apply('spatial.overlap.place_points_in_overlap', on='overlaps', distribute_points_kwargs=distribute_points_kwargs)
+        >>> njobs = ncg.apply('spatial.overlap.place_points_in_overlap',\
+            on='overlaps', distribute_points_kwargs=distribute_points_kwargs)
         """
 
         # Determine which obj will be called

--- a/autocnet/io/db/model.py
+++ b/autocnet/io/db/model.py
@@ -229,6 +229,12 @@ class Overlay(BaseMixin, Base):
     intersections = Column(ARRAY(Integer))
     #geom = Column(Geometry(geometry_type='POLYGON', management=True))  # sqlite
     _geom = Column("geom", Geometry('POLYGON', srid=latitudinal_srid, dimension=2, spatial_index=True))  # postgresql
+    points = relationship('Points',
+                          primaryjoin='func.ST_Contains(foreign(Overlay.geom), Points.geom).as_comparison(1,2)',
+                          backref=backref('overlay', uselist=False),
+                          viewonly=True,
+                          uselist=True)
+
 
     @hybrid_property
     def geom(self):


### PR DESCRIPTION
I was running into an issue where points were not being placed in overlaps. This was because I was using the 'new' method on CTX image overlaps with a large N/S extent and almost no E/W extent. 

I wanted to be able to place points into overlaps that did not already have points. When the config as refactored, calls to place_points_in_overlaps were replaced with an apply of place_points_in_overlap. The apply func on the network can take a filter kwarg. I started looking at how to pass the filter in for things like doing an inner join or applying a spatial function. Long story short, this would have resulted in a pretty crazy API where filters would need to define operators, external functions, functions on objects, etc. Not something to do.

So, this PR adds a query_string argument to the apply method. In the simple case of attribute equivalency it is probably easier to use the filter and the simple booleans it supports. In the more complex case (such as placing points with a spatial intersection) the method now supports straight SQL.

Piggybacking on this, a nice to have is a relationship between points and overlay. This has been added to the model so that one can do overlay.points and get back a list of the points that intersect a given overlap.