### PR TITLE
Database/Project Merging

### DIFF
--- a/autocnet/cg/cg.py
+++ b/autocnet/cg/cg.py
@@ -8,15 +8,13 @@ import geopandas as gpd
 import ogr
 
 from skimage import transform as tf
-from scipy.spatial import ConvexHull
-from scipy.spatial import Voronoi
+from scipy.spatial import ConvexHull, Voronoi
 import shapely.geometry
 from shapely.geometry import Polygon, Point
 from shapely.affinity import scale
 from shapely import wkt
 
 from autocnet.utils import utils
-
 
 
 def two_point_extrapolate(x, xs, ys):

--- a/autocnet/graph/merge.py
+++ b/autocnet/graph/merge.py
@@ -1,0 +1,123 @@
+from itertools import combinations
+from shapely.ops import cascaded_union
+import sqlalchemy
+from sqlalchemy.orm import subqueryload
+import geoalchemy2
+
+from autocnet.io.db.model import Points
+
+
+def insert_points_notin_geom(destination_network, networks, srid=949900):
+    """
+    Given a destination network and a list of networks, compute the intersection of
+    of the image boundry footprints. Any points inside of these areas are from overlapping
+    networks. This function finds all points outside the intersection and then
+    adds them to the database. Since these points do not already exist in the DB they can
+    be added without any need to merge.
+
+    Parameters
+    ----------
+    destination_network : object
+                          NetworkCandidateGraph object (can be empty)
+
+    networks : list
+               of NetworkCandidateGraphs objects from which images are merged
+
+    srid : int
+           The SRID of the geometry that is computed from the intersection of 
+           the network footprints.
+    Returns
+    -------
+    None
+    """
+    all_networks = networks + [destination_network]
+    intersection = cascaded_union([a.intersection(b) for a, b in combinations([i.footprint for i in all_networks], 2)])
+    # Convert the geom to a geoalchemy2 type for DB queries
+    geom = geoalchemy2.shape.from_shape(intersection, srid=srid)
+    
+    for network in networks:
+        with network.session_scope() as s_session:
+            # Spatial filter for all the points not in the intersection and then eager load the associated measures
+            to_be_added = s_session.query(Points).filter(sqlalchemy.not_(geoalchemy2.functions.ST_Within(Points.geom, geom))).options(subqueryload(Points.measures)).all()
+            
+            # Convert the rows to dicts
+            add_as_dicts = [obj.to_dict() for obj in to_be_added]
+            
+            # Update the primary keys for the Points, Measures since these are autoincrementing 
+            for point in add_as_dicts:
+                point.pop('id')
+                for measure in point['measures']:
+                    measure.pop('pointid')
+                    measure.pop('id')
+            
+            with destination_network.session_scope() as d_session:
+                d_session.bulk_insert_mappings(Points, add_as_dicts)
+    
+    return
+networks = [ncgA, ncgB]
+intersection = cascaded_union([a.intersection(b) for a, b in combinations([i.footprint for i in networks], 2)])
+
+def merge_images(destination_network, networks):
+    """
+    Given a destination network (database) and a list of network candidate graphs
+    insert all images not in the destination network from the input list of
+    networks.
+
+    Parameters
+    ----------
+    destination_network : object
+                          NetworkCandidateGraph object (can be empty)
+
+    networks : list
+               of NetworkCandidateGraphs objects from which images are merged
+
+    Returns
+    -------
+    None
+    """
+
+    sql = """INSERT INTO {0}.images 
+    SELECT t.*
+    FROM
+    (SELECT * FROM {0}.images
+    UNION 
+    SELECT * FROM {1}.images) AS t
+    ON CONFLICT DO NOTHING"""
+
+    with destination_network.session_scope() as d_session:
+        d_schema = destination_network.schema
+        for n in networks:
+            s_schema = n.schema
+            d_session.execute(sql.format(d_schema, s_schema))
+
+def merge_overlaps(destination_network, networks):
+    """
+    Naively merges the overlap tables from the list of networks into the destination_network. This
+    naive merge should be fine for now because we do not use the overlap/overlay table once
+    we are at the point that the projects are merging. 
+
+    TODO: update to recompute the overlaps for a true merge
+
+    Parameters
+    ----------
+    destination_network : object
+                          NetworkCandidateGraph object (can be empty)
+
+    networks : list
+               of NetworkCandidateGraphs objects from which images are merged
+
+    Returns
+    -------
+    None  
+    """
+    
+    sql = """INSERT INTO {0}.overlay
+    SELECT *
+    FROM
+    {1}.overlay
+    ON CONFLICT DO NOTHING"""
+    with destination_network.session_scope() as d_session:
+        d_schema = destination_network.schema
+        for network in networks:
+            s_schema = network.schema
+            d_session.execute(sql.format(d_schema, s_schema))

--- a/autocnet/graph/merge.py
+++ b/autocnet/graph/merge.py
@@ -1,12 +1,8 @@
 import copy
-from itertools import combinations
-from shapely.ops import cascaded_union
-import sqlalchemy
-from sqlalchemy.orm import subqueryload
-import geoalchemy2
+from scipy.spatial import cKDTree
 
-from autocnet.io.db.model import Points
-
+from autocnet.io.db.model import Points, Measures
+from autocnet.transformation.spatial import ll_to_eqc
 
 def create_new_from_existing(source_ncg, schema_name):
     """
@@ -37,56 +33,6 @@ def create_new_from_existing(source_ncg, schema_name):
     destination_config['database']['schema'] = schema_name
     destination_ncg.config_from_dict(destination_config)
     return destination_ncg
-
-def insert_points_notin_geom(destination_network, networks, srid=949900):
-    """
-    Given a destination network and a list of networks, compute the intersection of
-    of the image boundry footprints. Any points inside of these areas are from overlapping
-    networks. This function finds all points outside the intersection and then
-    adds them to the database. Since these points do not already exist in the DB they can
-    be added without any need to merge.
-
-    Parameters
-    ----------
-    destination_network : object
-                          NetworkCandidateGraph object (can be empty)
-
-    networks : list
-               of NetworkCandidateGraphs objects from which images are merged
-
-    srid : int
-           The SRID of the geometry that is computed from the intersection of 
-           the network footprints.
-    Returns
-    -------
-    None
-    """
-    all_networks = networks + [destination_network]
-    intersection = cascaded_union([a.intersection(b) for a, b in combinations([i.footprint for i in all_networks], 2)])
-    # Convert the geom to a geoalchemy2 type for DB queries
-    geom = geoalchemy2.shape.from_shape(intersection, srid=srid)
-    
-    for network in networks:
-        with network.session_scope() as s_session:
-            # Spatial filter for all the points not in the intersection and then eager load the associated measures
-            to_be_added = s_session.query(Points).filter(sqlalchemy.not_(geoalchemy2.functions.ST_Within(Points.geom, geom))).options(subqueryload(Points.measures)).all()
-            
-            # Convert the rows to dicts
-            add_as_dicts = [obj.to_dict() for obj in to_be_added]
-            
-            # Update the primary keys for the Points, Measures since these are autoincrementing 
-            for point in add_as_dicts:
-                point.pop('id')
-                for measure in point['measures']:
-                    measure.pop('pointid')
-                    measure.pop('id')
-            
-            with destination_network.session_scope() as d_session:
-                d_session.bulk_insert_mappings(Points, add_as_dicts)
-    
-    return
-networks = [ncgA, ncgB]
-intersection = cascaded_union([a.intersection(b) for a, b in combinations([i.footprint for i in networks], 2)])
 
 def merge_images(destination_network, networks):
     """
@@ -152,3 +98,169 @@ def merge_overlaps(destination_network, networks):
         for network in networks:
             s_schema = network.schema
             d_session.execute(sql.format(d_schema, s_schema))
+
+
+def _subpixel_register_merged_measures(ncg, to_match, **kwargs):
+    mids = []
+    with ncg.session_scope() as session:
+        for serial, pointid in to_match:
+            mid = session.query(Measures).filter(Measures.serial == serial, Measures.pointid == pointid).one()
+            mids.append(mid.id)
+
+    # Then apply the registration on the cluster
+    sql = f"SELECT * FROM merged.measures WHERE measures.id IN {tuple(mids)}"
+    destination_ncg.apply('matcher.subpixel.subpixel_register_measure', on='measures', query_string=sql, **kwargs)
+
+def _gdfnearest(gdA, gdB, semimajor, semiminor):
+    """
+    Compute the nearest neighbor between two pandas data frames. This func also
+    takes the semi-major and semi-minor axes of the body as it projects the points
+    from lat/lon to equirectangular space.
+    
+    Parameters
+    ----------
+    gdA : DataFrame
+          With an 'id' column and a 'geom' column. This is the source dataframe
+          that is used to query the destination dataframe (gdB).
+          
+    gdB : DataFrame
+          With an 'id' column and a 'geom' column or an empty pandas data frame.
+          This is the destination dataframe that against which the source (gdA)
+          queries.
+          
+    semimajor : numeric
+                Semi-major axis of the body
+                
+    semiminor : numeric
+                Semi-minor axis of the body
+                
+    Returns
+    -------
+    gdf : DataFrame
+          Containing the source point, the nearest destination point, and an added 
+          'dist' column. If the destination is empty, the row contains only the source
+          point and a dist equal to zero.
+          
+    """
+    # Rename the id columns because these ar
+    gdA.rename(columns={'id':'source_id'}, inplace=True)
+    gdB.rename(columns={'id':'destin_id'}, inplace=True)
+    # Convert the geom obj to lists
+    nA = np.array(list(gdA['geom'].apply(lambda x: (x.x, x.y))))
+    nB = np.array(list(gdB['geom'].apply(lambda x: (x.x, x.y))))
+    
+    # Project into equirectangular (meters unit) so that distances
+    # are intuitive for defining a threshold
+    nA[:,0], nA[:,1] = lla_to_eqc(nA, semimajor, semiminor)
+    
+    # If nB is empty, set the distances to infinity
+
+    if len(nB) == 0:
+        dist = pd.Series(np.zeros(len(nA)), name='dist')
+        dist[:] = np.inf
+        gdf = pd.concat([gdA.reset_index(drop=True), dist], axis=1)
+        return gdf
+    
+    # Else compute the distances
+    nB[:,0], nB[:,1] = lla_to_eqc(nB, semimajor, semiminor)
+    btree = cKDTree(nB)
+    dist, idx = btree.query(nA, k=1)
+    
+    # Find the nearest
+    gdf = pd.concat(
+        [gdA.reset_index(drop=True), gdB.loc[idx, gdB.columns != 'geometry'].reset_index(drop=True),
+         pd.Series(dist, name='dist')], axis=1)
+    return gdf
+
+def merge(destination_ncg, 
+          ncgs, 
+          threshold=24,
+          subpixel_kwargs={}):
+    """
+    Given a destination network and one or more input networks, merge the input network(s)
+    into the destination network. If we have a network A, this function takes one or more 
+    input networks (B,C,D) and merges B,C,D into A resulting in a network composed of
+    A,B,C,D.
+
+    The method copies the points, measures, images, and overlaps from the input networks
+    into the destination networks.
+
+    Parameters
+    ----------
+    destination_ncg : obj
+                      An AutoCNet network candidate graph.
+
+    ncgs : obj / list
+           Either a single AutoCNet network candidate graph or a list of network
+           candidate graphs.
+
+    threshold : numeric 
+                The distance, in meters, within which measures will be considered 
+                co-incident. When measures are considered co-incident, they are
+                re-subpixel registered to the reference measure in the
+                destination graph.
+
+    subpixel_kwargs : dict
+                      With arguments passed to the subpixel matcher for those
+                      measures that are within the threshold.
+    """
+
+    if isinstance(ncgs, NetworkCandidateGraph):
+        ncgs = [ncgs]
+    
+    # Ensure that all the necessary images are in the destination database
+    merge_images(destination_ncg, ncgs)
+
+    # Ensure that all the overlaps are copied. This is naive at this point becase
+    # the overlaps are not used once we are at this point. This happens because
+    # the overlaps are a foreign key.
+    merge_overlaps(destination_ncg, ncgs)
+
+    # Merge the points/measures from each network. When points are within the
+    # threshold, the measures are merged and then the merging measures are
+    # asynchronously subpixel registered on the cluster.
+    for to_be_merged_ncg in ncgs:
+    
+        # Compute the nearest neighbor for each point in the db
+        gdA = to_be_merged_ncg.points
+        gdB = destination_ncg.points
+        gdf = _gdfnearest(gdA, gdB, semimajor, semiminor)
+
+        # Create an emtpy container to hold objects so that we can efficiently insert into the DB
+        to_add = []
+        to_rematch = []
+        ids_that_should_not_migrate = []
+        with to_be_merged_ncg.session_scope() as s_session, destination_ncg.session_scope() as d_session:  
+            for i, row in gdf.iterrows():
+                if row.dist <= threshold:
+                    updated_point_id = row['destin_id']
+                    ids_that_should_not_migrate.append(row['source_id'])
+                    # Determine which measures exist in the source that are not already in the destination
+                    # Do this using the set difference of the serial numbers
+                    destin_measures = d_session.query(Measures).filter(Measures.pointid == row.destin_id).all()
+                    source_measures = s_session.query(Measures).filter(Measures.pointid == row.source_id).all()
+
+                    destin_serials = set([i.serial for i in destin_measures])
+                    source_serials = set([i.serial for i in source_measures])
+                    serials_not_in_destin = source_serials - destin_serials
+
+                    measures_to_register_and_add = [i for i in source_measures if i.serial in serials_not_in_destin] 
+
+                    for m in measures_to_register_and_add:
+                        new_measure = m.duplicate()
+                        new_measure.pointid = row['destin_id']
+                        to_rematch.append((new_measure.serial, new_measure.pointid))
+                        to_add.append(new_measure)
+
+                else:
+                    # The point is outside the threshold, so simply copy it into the new DB
+                    point_to_copy = s_session.query(Points).filter(Points.id == row.source_id).one()
+                    to_add.append(point_to_copy.duplicate())
+
+            d_session.add_all(to_add)
+
+        # Subpixel register the measures that were added and within the given threshold. Since this happens
+        # on the cluster, it is asynchronous. This happens as a second pass so that the above session add
+        # gets all the primary keys setup.
+        if to_rematch:
+            _subpixel_register_merged_measures(destination_ncg, to_rematch, **subpixel_kwargs)

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -18,6 +18,7 @@ import shapely
 import geoalchemy2
 import sqlalchemy
 from sqlalchemy.ext.declarative.api import DeclarativeMeta
+from sqlalchemy_utils import database_exists
 import shapely.affinity
 import shapely.geometry
 import shapely.wkt as swkt
@@ -1422,7 +1423,10 @@ class NetworkCandidateGraph(CandidateGraph):
         db = self.config['database']
         self.Session, self.engine = new_connection(self.config['database'])
 
-        # Attempt to create the database (if it does not exist)
+        # If the db does not exist and/or the schema does not exist, create them
+        #if not database_exists(self.engine.url) or\
+        #   not self.engine.dialect.has_schema(self.engine, self.schema):
+        
         try_db_creation(self.engine, self.config)
 
     def _setup_queues(self):

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -2045,6 +2045,16 @@ class NetworkCandidateGraph(CandidateGraph):
         return networkobj
     
     @property
+    def footprint(self):
+        """
+        Returns the footprint created by merging all of the valid images in the graph 
+        """
+        with self.session_scope() as session:
+            # Have to grab index 0 because the res is a tuple (geom, )
+            res = session.query(geoalchemy2.functions.ST_AsText(geoalchemy2.functions.ST_Union(Images.geom))).one()[0]
+        return shapely.wkt.loads(res)
+    
+    @property
     def measures(self):
         df = pd.read_sql_table('measures', con=self.engine)
         return df

--- a/autocnet/io/db/connection.py
+++ b/autocnet/io/db/connection.py
@@ -4,6 +4,9 @@ import sqlalchemy
 from sqlalchemy import create_engine, pool, orm
 from sqlalchemy.orm import create_session, scoped_session, sessionmaker
 
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import Insert
+
 import os
 import socket
 import warnings
@@ -41,3 +44,7 @@ def new_connection(dbconfig):
                 isolation_level="AUTOCOMMIT")
     Session = orm.sessionmaker(bind=engine, autocommit=False)
     return Session, engine
+
+@compiles(Insert)
+def prefix_inserts(insert, compiler, **kw):
+    return compiler.visit_insert(insert, **kw) + " ON CONFLICT DO NOTHING"

--- a/autocnet/io/db/connection.py
+++ b/autocnet/io/db/connection.py
@@ -37,6 +37,7 @@ def new_connection(dbconfig):
     engine = sqlalchemy.create_engine(db_uri,
                 poolclass=sqlalchemy.pool.NullPool,
                 connect_args={"application_name":f"AutoCNet_{hostname}"},
+                execution_options={'schema_translate_map':{'dynamic' : dbconfig['schema']}},
                 isolation_level="AUTOCOMMIT")
     Session = orm.sessionmaker(bind=engine, autocommit=False)
     return Session, engine

--- a/autocnet/io/db/connection.py
+++ b/autocnet/io/db/connection.py
@@ -47,4 +47,4 @@ def new_connection(dbconfig):
 
 @compiles(Insert)
 def prefix_inserts(insert, compiler, **kw):
-    return compiler.visit_insert(insert, **kw) + " ON CONFLICT DO NOTHING"
+    return compiler.visit_insert(insert, **kw) #+ " ON CONFLICT DO NOTHING"

--- a/autocnet/io/db/triggers.py
+++ b/autocnet/io/db/triggers.py
@@ -1,7 +1,8 @@
 from sqlalchemy.schema import DDL
 
-valid_geom_function = DDL("""
-CREATE OR REPLACE FUNCTION validate_geom()
+def valid_geom_function(schema):
+  return DDL(f"""
+CREATE OR REPLACE FUNCTION {schema}.validate_geom()
   RETURNS trigger AS
 $BODY$
   BEGIN
@@ -17,16 +18,18 @@ LANGUAGE plpgsql VOLATILE -- Says the function is implemented in the plpgsql lan
 COST 100; -- Estimated execution cost of the function.
 """)
 
-valid_geom_trigger = DDL("""
+def valid_geom_trigger(schema):
+  return DDL(f"""
 CREATE TRIGGER image_inserted
   BEFORE INSERT OR UPDATE
-  ON images
+  ON {schema}.images
   FOR EACH ROW
 EXECUTE PROCEDURE validate_geom();
 """)
 
-valid_point_function = DDL("""
-CREATE OR REPLACE FUNCTION validate_points()
+def valid_point_function(schema):
+  return DDL(f"""
+CREATE OR REPLACE FUNCTION {schema}.validate_points()
   RETURNS trigger AS
 $BODY$
 BEGIN
@@ -51,16 +54,18 @@ LANGUAGE plpgsql VOLATILE -- Says the function is implemented in the plpgsql lan
 COST 100; -- Estimated execution cost of the function.
 """)
 
-valid_point_trigger = DDL("""
+def valid_point_trigger(schema):
+  return DDL(f"""
 CREATE TRIGGER active_measure_changes
   AFTER UPDATE
-  ON measures
+  ON {schema}.measures
   FOR EACH ROW
 EXECUTE PROCEDURE validate_points();
 """)
 
-ignore_image_function = DDL("""
-CREATE OR REPLACE FUNCTION ignore_image()
+def ignore_image_function(schema):
+  return DDL(f"""
+CREATE OR REPLACE FUNCTION {schema}.ignore_image()
   RETURNS trigger AS
 $BODY$
 BEGIN
@@ -79,10 +84,11 @@ LANGUAGE plpgsql VOLATILE -- Says the function is implemented in the plpgsql lan
 COST 100; -- Estimated execution cost of the function.
 """)
 
-ignore_image_trigger = DDL("""
+def ignore_image_trigger(schema):
+  return DDL(f"""
 CREATE TRIGGER image_ignored
   AFTER UPDATE
-  ON images
+  ON {schema}.images
   FOR EACH ROW
 EXECUTE PROCEDURE ignore_image();
 """)

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -27,16 +27,16 @@ WITH intersectiongeom AS
    SELECT ST_Polygonize(the_geom) AS the_geom FROM (
      SELECT ST_Union(the_geom) AS the_geom FROM (
      SELECT ST_ExteriorRing((ST_DUMP(geom)).geom) AS the_geom
-       FROM images WHERE images.geom IS NOT NULL) AS lines
+       FROM {0}images WHERE {0}images.geom IS NOT NULL) AS lines
   ) AS noded_lines))),
 iid AS (
  SELECT images.id, intersectiongeom.geom AS geom
-    FROM images, intersectiongeom
-    WHERE images.geom is NOT NULL AND
-    ST_INTERSECTS(intersectiongeom.geom, images.geom) AND
-    ST_AREA(ST_INTERSECTION(intersectiongeom.geom, images.geom)) > 0.000001
+    FROM {0}images, intersectiongeom
+    WHERE {0}images.geom is NOT NULL AND
+    ST_INTERSECTS(intersectiongeom.geom, {0}images.geom) AND
+    ST_AREA(ST_INTERSECTION(intersectiongeom.geom, {0}images.geom)) > 0.000001
 )
-INSERT INTO overlay(intersections, geom) SELECT row.intersections, row.geom FROM
+INSERT INTO {0}overlay(intersections, geom) SELECT row.intersections, row.geom FROM
 (SELECT iid.geom, array_agg(iid.id) AS intersections
   FROM iid GROUP BY iid.geom) AS row WHERE array_length(intersections, 1) > 1;
 """

--- a/autocnet/transformation/spatial.py
+++ b/autocnet/transformation/spatial.py
@@ -40,3 +40,30 @@ def reproject(record, semi_major, semi_minor, source_proj, dest_proj, **kwargs):
 
     y, x, z = pyproj.transform(source_pyproj, dest_pyproj, record[0], record[1], record[2], **kwargs)
     return y, x, z
+
+def ll_to_eqc(points, semimajor, semiminor):
+    """
+    Project from Lat/Lon to Equirectangular. This func works with points
+    in 2D.
+    
+    Parameters
+    ----------
+    points : ndarray
+             (n,2) array of ppoint coordinates in form (lat, lon)
+             
+    semimajor : numeric
+                Semi-major axis of the body
+                
+    semiminor : numeric
+                Semi-minor axis of the body
+                
+    Returns
+    -------
+     : ndarray
+       (n,2) array of coordinates in meters in an equirectangular projection
+       
+    """
+    ll = f"+proj=latlon +a={semimajor} +b={semiminor}"
+    eqc = f"+proj=eqc +units=m +a={semimajor} +b={semiminor}"
+    
+    return pyproj.transform(ll, eqc, points[:,0], points[:,1])


### PR DESCRIPTION
This PR executes a few refactors in order to support merging autocnet projects/databases. The most significant is that the underlying database is now using schemas. From my reading, we should be using schemas anyway because the schemas are designed to support a higher number of instances, within a single database. Apparently postgres can be unhappy when the instance has a high number of discrete databases.

As it stands now, the PR merges all the easy stuff: images, overlaps, non-overlapping points. Working on the overlapping areas where points have to be merged still.