### PR TITLE
Adding cost kwargs to propagate_control_network plus bug fix

### DIFF
--- a/autocnet/graph/edge.py
+++ b/autocnet/graph/edge.py
@@ -17,7 +17,7 @@ from autocnet.matcher import subpixel as sp
 from autocnet.matcher import cpu_ring_matcher
 from autocnet.transformation import fundamental_matrix as fm
 from autocnet.transformation import homography as hm
-from autocnet.transformation.spatial import reproject
+from autocnet.transformation.spatial import reproject, og2oc
 from autocnet.vis.graph_view import plot_edge, plot_node, plot_edge_decomposition, plot_matches
 from autocnet.cg import cg
 from autocnet.io.db.model import Images, Keypoints, Matches,\
@@ -237,8 +237,10 @@ class Edge(dict, MutableMapping):
             ic = csmapi.ImageCoord(coords[i][0], coords[i][1])
             ground = camera.imageToGround(ic, 0)
             gnd[i] = [ground.x, ground.y, ground.z]
-        lon, lat, alt = reproject(gnd.T, semimajor, semiminor,
+        lon_og, lat_og, alt = reproject(gnd.T, semimajor, semiminor,
                                     'geocent', 'latlon')
+        lon, lat = og2oc(lon_og, lat_og, semimajor, semiminor)
+
         if srid:
             geoms = []
             for coord in zip(lon, lat, alt):
@@ -963,7 +965,8 @@ class NetworkEdge(Edge):
                 session.add(edge)
 
     def get_overlapping_indices(self, kps):
-        lons, lats, alts = reproject([kps.xm.values, kps.ym.values, kps.zm.values], semi_major, semi_minor, 'geocent', 'latlon')
+        lons_og, lats_og, alts = reproject([kps.xm.values, kps.ym.values, kps.zm.values], semi_major, semi_minor, 'geocent', 'latlon')
+        lons, lats = og2oc(lons_og, lats_og, semi_major, semi_minor)
         points = [Point(lons[i], lats[i]) for i in range(len(lons))]
         mask = [i for i in range(len(points)) if self.intersection.contains(points[i])]
         return mask
@@ -1063,7 +1066,7 @@ class NetworkEdge(Edge):
         mask = self.masks[mask]
         matches_to_disable = mask[mask == False].index
 
-        
+
         bad = {}
         with self.parent.session_scope() as session:
             for o in session.query(Matches).filter(Matches.id.in_(matches_to_disable)).all():

--- a/autocnet/io/db/controlnetwork.py
+++ b/autocnet/io/db/controlnetwork.py
@@ -82,6 +82,6 @@ ORDER BY measures."pointid", measures."id";
                     row['adjustedX'] = adjusted_geom.x
                     row['adjustedY'] = adjusted_geom.y
                     row['adjustedZ'] = adjusted_geom.z
-            df[i] = row
-            
+                df.iloc[i] = row
+
         return df

--- a/autocnet/io/db/model.py
+++ b/autocnet/io/db/model.py
@@ -294,7 +294,7 @@ class Points(BaseMixin, Base):
     @hybrid_property
     def geom(self):
         try:
-            return to_shape(self._geom, srid=self.latitudinal_srid)
+            return to_shape(self._geom)
         except:
             return self._geom
 

--- a/autocnet/io/db/model.py
+++ b/autocnet/io/db/model.py
@@ -18,7 +18,7 @@ from geoalchemy2.shape import from_shape, to_shape
 import osgeo
 import shapely
 from shapely.geometry import Point
-from autocnet.transformation.spatial import reproject
+from autocnet.transformation.spatial import reproject, og2oc
 from autocnet.utils.serializers import JsonEncoder
 
 Base = declarative_base()
@@ -294,7 +294,7 @@ class Points(BaseMixin, Base):
     @hybrid_property
     def geom(self):
         try:
-            return to_shape(self._geom)
+            return to_shape(self._geom, srid=self.latitudinal_srid)
         except:
             return self._geom
 
@@ -328,10 +328,11 @@ class Points(BaseMixin, Base):
     def adjusted(self, adjusted):
         if adjusted:
             self._adjusted = from_shape(adjusted, srid=self.rectangular_srid)
-            lat, lon, _ = reproject([adjusted.x, adjusted.y, adjusted.z],
+            lon_og, lat_og, _ = reproject([adjusted.x, adjusted.y, adjusted.z],
                                     self.semimajor_rad, self.semiminor_rad,
                                     'geocent', 'latlon')
-            self._geom = from_shape(Point(lat, lon), self.latitudinal_srid)
+            lon, lat = og2oc(lon_og, lat_og, self.semimajor_rad, self.semiminor_rad)
+            self._geom = from_shape(Point(lon, lat), srid=self.latitudinal_srid)
         else:
             self._adjusted = adjusted
             self._geom = None

--- a/autocnet/matcher/cross_instrument_matcher.py
+++ b/autocnet/matcher/cross_instrument_matcher.py
@@ -47,7 +47,7 @@ from autocnet.io.db.model import Images, Points, Measures, JsonEncoder
 from autocnet.cg.cg import distribute_points_in_geom, xy_in_polygon
 from autocnet.io.db.connection import new_connection
 from autocnet.spatial import isis
-from autocnet.transformation.spatial import reproject
+from autocnet.transformation.spatial import reproject, oc2og
 from autocnet.matcher.cpu_extractor import extract_most_interesting
 from autocnet.transformation import roi
 from autocnet.matcher.subpixel import geom_match
@@ -168,8 +168,75 @@ def propagate_point(Session,
                     size_x=40,
                     size_y=40,
                     template_kwargs={'image_size': (39, 39), 'template_size': (21, 21)},
-                    verbose=False):
+                    verbose=False,
+                    cost=lambda x, y: y == np.max(x)):
     """
+    Conditionally propagate a point into a stack of images. The point and all corresponding measures
+    are matched against database netwrok (to which you are propagating), best result(s) is(are) kept.
+
+    Parameters
+    ----------
+    Session   : sqlalchemy.sessionmaker
+                session maker associated with the database you want to propagate to
+
+    config    : dict
+                configuation file associated with database you want to propagate to
+                In the form: {'username':'somename',
+                              'password':'somepassword',
+                              'host':'somehost',
+                              'pgbouncer_port':6543,
+                              'name':'somename'}
+
+    dem       : plio.io.io_gdal.GeoDataset
+                digital elevation model of target body
+
+    lon       : np.float
+                longitude of point you want to project
+
+    lat       : np.float
+                latitude of point you want to project
+
+    pointid   : int
+                clerical input used to trace point from generate_ground_points output
+
+    paths     : list of str
+                absolute paths pointing to the image(s) from which you want to try porpagating the point
+
+    lines     : list of np.float
+                apriori line(s) corresponding to point projected in 'paths' image(s)
+
+    samples   : list of np.float
+                apriori sample(s) corresponding to point projected in 'paths' image(s)
+
+    size_x    : int
+                size of GeoDataset used in geom_match, must be larger than template_kwargs 'image_size'
+
+    size_y    : int
+                size of GeoDataset used in geom_match, must be larger than template_kwargs 'image_size'
+
+    template_kwargs : dict
+                      kwargs passed through to control matcher.subpixel_template()
+
+    verbose   : boolean
+                If True, this will print out the results of each propagation, including prints of the
+                matcher areas and their correaltion map.
+
+    cost      : anonymous function
+                determines to which image(s) the point should be propagated. x corresponds to a list
+                of all match correlation metrics, while y corresponds to each indiviudal element
+                of the x array.
+                Example:
+                cost = lambda x,y: y == np.max(x) will get you one result corresponding to the image that
+                has the maximum correlation with the source image
+                cost = lambda x,y: y > 0.6 will propegate the point to all images whose correlation
+                result is greater than 0.6
+
+
+    Output
+    ----------
+    new_measures : pd.DataFrame
+                   Dataframe containing pointid, imageid, image serial number, line, sample, and ground location (both latlon
+                   and cartesian) of successfully propagated points
 
     """
     session = Session()
@@ -184,17 +251,30 @@ def propagate_point(Session,
     p = Point(lon, lat)
     new_measures = []
 
+    print("point id: ", pointid)
+    print("number of CTX images: ", len(images))
+    print("images: ", images)
+    print("lines: ", lines)
+    print("samples: ", samples)
+    print("paths: ", paths)
+    print()
+
+    # list of matching results in the format:
+    # [measure_index, x_offset, y_offset, offset_magnitude]
+    match_results = []
     # lazily iterate for now
-    for i,image in images.iterrows():
-        dest_image = GeoDataset(image["path"])
+    for k,m in image_measures.iterrows():
+        print('base source: ', m['path'])
+        base_image = GeoDataset(m["path"])
 
-        # list of matching results in the format:
-        # [measure_index, x_offset, y_offset, offset_magnitude]
-        match_results = []
-        for k,m in image_measures.iterrows():
-            base_image = GeoDataset(m["path"])
+        sx, sy = m["sample"], m["line"]
 
-            sx, sy = m["sample"], m["line"]
+        for i,image in images.iterrows():
+            print('destination source: ', image['path'])
+            dest_image = GeoDataset(image["path"])
+
+            if os.path.basename(m['path']) == os.path.basename(image['path']):
+                continue
 
             try:
                 x,y, dist, metrics, corrmap = geom_match(base_image, dest_image, sx, sy, \
@@ -202,66 +282,92 @@ def propagate_point(Session,
                         template_kwargs=template_kwargs, \
                         verbose=verbose)
             except Exception as e:
+                print('RAISING EXCEPTION')
                 raise Exception(e)
                 match_results.append(e)
                 continue
 
+            if len(images) > 1:
+                print('append to match_results')
+                print('shit to append: ', [k, x, y, metrics, dist, m['path'], image['path']])
             match_results.append([k, x, y,
-                                     metrics, dist, corrmap, m["path"], image["path"]])
+                                     metrics, dist, corrmap, m["path"], image["path"],
+                                     image['id'], image['serial']])
+            if len(images) > 1:
+                print('match_results length: ', len(match_results))
 
-        # get best offsets, if possible we need better metric for what a
-        # good match looks like
-        match_results = np.asarray([res for res in match_results if isinstance(res, list)])
-        if match_results.shape[0] == 0:
-            # no matches
-            continue
+    # get best offsets
+    match_results = np.asarray([res for res in match_results if isinstance(res, list) and all(r is not None for r in res)])
+    print("match_results final length: ", len(match_results))
+    if match_results.shape[0] == 0:
+        # no matches
+        return new_measures
 
-        best_results = match_results[np.argwhere(match_results[:,3] == match_results[:,3].max())][0][0]
+    best_results = np.asarray([match for match in match_results if cost(match_results[:,3], match[3])])
+    print("best_results length: ", len(best_results))
+    if best_results.shape[0] == 0:
+        # no matches satisfying cost
+        return new_measures
 
-        # apply offsets
-        sample = best_results[1]
-        line = best_results[2]
+    print('best_results: ', best_results)
+    print('\n')
+    if verbose:
+        print("Full results: ", best_results)
+        print("Winning CORRs: ", best_results[:,3], "Themis Pixel shifts: ", best_results[:,4])
+        print("Themis Images: ", best_results[:,6], "CTX images:", best_results[:,7])
+        print("Themis Sample: ", sx, "CTX Samples: ", best_results[:,1])
+        print("Themis Line: ", sy, "CTX Lines: ", best_results[:,2])
+        print('\n')
 
-        if verbose:
-          print("Full results: ", best_results)
-          print("Winning CORR: ", best_results[3], "Themis Pixel shift: ", best_results[4])
-          print("Themis Image: ", best_results[6], "CTX image:", best_results[7])
-          print("Themis S,L: ", f"{sx},{sy}", "CTX S,L: ", f"{sample},{line}")
-          print('\n')
+    if len(best_results[:,3])==1 and best_results[:,3][0] is None:
+        return new_measures
 
-        # hardcoded for now
-        if best_results[3] == None or best_results[3] < 0.7:
-            continue
+    px, py = dem.latlon_to_pixel(lat, lon)
+    height = dem.read_array(1, [px, py, 1, 1])[0][0]
 
-        px, py = dem.latlon_to_pixel(lat, lon)
-        height = dem.read_array(1, [px, py, 1, 1])[0][0]
-
-        semi_major = config['spatial']['semimajor_rad']
-        semi_minor = config['spatial']['semiminor_rad']
-        # The CSM conversion makes the LLA/ECEF conversion explicit
-        x, y, z = reproject([lon, lat, height],
+    semi_major = config['spatial']['semimajor_rad']
+    semi_minor = config['spatial']['semiminor_rad']
+    # The CSM conversion makes the LLA/ECEF conversion explicit
+    # reprojection takes ographic lat
+    lon_og, lat_og = oc2og(lon, lat, semi_major, semi_minor)
+    x, y, z = reproject([lon_og, lat_og, height],
                          semi_major, semi_minor,
                          'latlon', 'geocent')
 
+    for row in best_results:
+        sample = row[1]
+        line = row[2]
+
         new_measures.append({
-                'pointid' : pointid,
-                'imageid' : image['id'],
-                'serial' : image['serial'],
-                'line' : line,
-                'sample' : sample,
-                'point_latlon' : p,
-                'point_ground' : Point(x*1000, y*1000, z*1000)
-        })
+            'pointid' : pointid,
+            'imageid' : row[8],
+            'serial' : row[9],
+            'path': row[7],
+            'line' : line,
+            'sample' : sample,
+            'point' : p,
+            'point_ecef' : Point(x, y, z)
+            })
 
     return new_measures
 
-def propagate_control_network(Session, config, dem, base_cnet,
-        size_x=40, size_y=40,
-        template_kwargs={'image_size': (39,39), 'template_size': (21,21)}, verbose=False):
+def propagate_control_network(Session,
+        config,
+        dem,
+        base_cnet,
+        size_x=40,
+        size_y=40,
+        template_kwargs={'image_size': (39,39), 'template_size': (21,21)},
+        verbose=False,
+        cost=lambda x,y: y == np.max(x)):
     """
+    Propagate a contorl network made of line, sample, image path to a network contained within
+    a database.
+
+
     Parameters
     ----------
-    Session   : sqlalchemy session maker
+    Session   : sqlalchemy.sessionmaker
                 session maker associated with the database you want to propagate to
 
     config    : dict
@@ -276,16 +382,28 @@ def propagate_control_network(Session, config, dem, base_cnet,
                 Digital elevation model of target body
 
     base_cnet : pd.DataFrame
-                Dataframe representing the points you want to propagate. Must contain line, sample, path.
+                Dataframe representing the points you want to propagate. Must contain 'line', 'sample' location of
+                the measure and the 'path' to the corresponding image
 
     verbose   : boolean
                 Increase the level of print outs/plots recieved during propagation
+
+    cost      : anonymous function
+                determines to which image(s) the point should be propagated. x corresponds to a list
+                of all match correlation metrics, while y corresponds to each indiviudal element
+                of the x array.
+                Example:
+                cost = lambda x,y: y == np.max(x) will get you one result corresponding to the image that
+                has the maximum correlation with the source image
+                cost = lambda x,y: y > 0.6 will propegate the point to all images whose correlation
+                result is greater than 0.6
 
 
     Output
     ------
     ground   : pd.DataFrame
-               Dataframe containing successfully propagated points
+               Dataframe containing pointid, imageid, image serial number, line, sample, and ground location (both latlon
+               and cartesian) of successfully propagated points
 
     """
     warnings.warn('This function is not well tested. No tests currently exists \
@@ -317,37 +435,70 @@ def propagate_control_network(Session, config, dem, base_cnet,
                                       size_x,
                                       size_y,
                                       template_kwargs,
-                                      verbose=verbose)
+                                      verbose=verbose,
+                                      cost=cost)
+        if len(gp_measures) == 0:
+            continue
 
         constrained_net.extend(gp_measures)
 
-    ground = gpd.GeoDataFrame.from_dict(constrained_net).set_geometry('point_latlon')
+    ground = gpd.GeoDataFrame.from_dict(constrained_net).set_geometry('point')
     groundpoints = ground.groupby('pointid').groups
 
     points = []
 
     # upload new points
+    session = Session()
     for p,indices in groundpoints.items():
         point = ground.loc[indices].iloc[0]
-        p = Points()
-        p.pointtype = 3
-        p.apriori = point['point_ground']
-        p.adjusted = point['point_ground']
+        # if point already exists in DB
+        lon = point.point.x
+        lat = point.point.y
+        res = session.execute(f"SELECT * FROM points WHERE ST_Intersects(geom, ST_Buffer(ST_SetSRID(ST_Point({lon}, {lat}), {config['spatial']['latitudinal_srid']}), 1e-10))").fetchall()
+        print(f'lon: {lon}, lat: {lat}')
+        print('length of result: ', len(res))
 
-        for i in indices:
-            m = ground.loc[i]
-            p.measures.append(Measures(line=float(m['line']),
-                                       sample = float(m['sample']),
-                                       aprioriline = float(m['line']),
-                                       apriorisample = float(m['sample']),
-                                       imageid = int(m['imageid']),
-                                       serial = m['serial'],
+        if len(res) > 1:
+            warnings.warn(f"There is more than one point at lon: {lon}, lat: {lat}")
+
+        elif len(res) == 1:
+            # same as below but controlling the pointid
+            for i in indices:
+                row = ground.loc[i]
+                pid = res[0][0]
+                meas = session.execute(f"SELECT serialnumber FROM measures WHERE pointid={pid}").fetchall()
+                serialnumbers = [m[0] for m in meas]
+
+                if row['serial'] in serialnumbers:
+                    continue
+
+                points.append(Measures(pointid = pid,
+                                       line=float(row['line']),
+                                       sample = float(row['sample']),
+                                       aprioriline = float(row['line']),
+                                       apriorisample = float(row['sample']),
+                                       imageid = int(row['imageid']),
+                                       serial = row['serial'],
                                        measuretype=3))
-        points.append(p)
+        else:
+            p = Points()
+            p.pointtype = 3
+            p.apriori = point['point_ecef']
+            p.adjusted = point['point_ecef']
+            for i in indices:
+                row = ground.loc[i]
+                p.measures.append(Measures(line=float(row['line']),
+                                           sample = float(row['sample']),
+                                           aprioriline = float(row['line']),
+                                           apriorisample = float(row['sample']),
+                                           imageid = int(row['imageid']),
+                                           serial = row['serial'],
+                                           measuretype=3))
+            points.append(p)
 
-    session = Session()
     session.add_all(points)
     session.commit()
+    session.close()
 
     return ground
 

--- a/autocnet/matcher/cross_instrument_matcher.py
+++ b/autocnet/matcher/cross_instrument_matcher.py
@@ -276,10 +276,9 @@ def propagate_point(Session,
                 match_results.append(e)
                 continue
 
-            if len(images) > 1:
             match_results.append([k, x, y,
-                                     metrics, dist, corrmap, m["path"], image["path"],
-                                     image['id'], image['serial']])
+                                 metrics, dist, corrmap, m["path"], image["path"],
+                                 image['id'], image['serial']])
 
     # get best offsets
     match_results = np.asarray([res for res in match_results if isinstance(res, list) and all(r is not None for r in res)])
@@ -430,7 +429,7 @@ def propagate_control_network(Session,
 
     points = []
 
-    # upload new points
+    # conditionally upload a new point to DB or updated existing point with new measures
     session = Session()
     for p,indices in groundpoints.items():
         point = ground.loc[indices].iloc[0]
@@ -443,7 +442,6 @@ def propagate_control_network(Session,
             warnings.warn(f"There is more than one point at lon: {lon}, lat: {lat}")
 
         elif len(res) == 1:
-            # same as below but controlling the pointid
             for i in indices:
                 row = ground.loc[i]
                 pid = res[0][0]

--- a/autocnet/transformation/spatial.py
+++ b/autocnet/transformation/spatial.py
@@ -1,4 +1,81 @@
 import pyproj
+import numpy as np
+
+def og2oc(lon, lat, semi_major, semi_minor):
+    """
+    Converts planetographic latitude to planetocentric latitude using pyproj pipeline.
+
+    Parameters
+    ----------
+    lon : float
+          longitude 0 to 360 domain (in degrees)
+
+    lat : float
+          planetographic latitude (in degrees)
+
+    semi_major : float
+                 Radius from the center of the body to the equator
+
+    semi_minor : float
+                 Radius from the center of the body to the pole
+
+    Returns
+    -------
+    lon: float
+         longitude (in degrees)
+
+    lat: float
+         planetocentric latitude (in degrees)
+    """
+    lon_og = np.radians(lon)
+    lat_og = np.radians(lat)
+
+    proj_str = f"""
+    +proj=pipeline
+    +step +proj=geoc +a={semi_major} +b={semi_minor} +lon_wrap=180 +xy_in=rad +xy_out=rad
+    """
+    og2oc = pyproj.transformer.Transformer.from_pipeline(proj_str)
+    lon_oc, lat_oc = og2oc.transform(lon_og, lat_og, errcheck=True, radians=True)
+    return np.degrees(lon_oc), np.degrees(lat_oc)
+
+def oc2og(lon, lat, semi_major, semi_minor):
+    """
+    Converts planetocentric latitude to planetographic latitude using pyproj pipeline.
+
+    Parameters
+    ----------
+    lon : float
+          longitude 0 to 360 domain (in degrees)
+
+    lat : float
+          planetocentric latitude (in degrees)
+
+    semi_major : float
+                 Radius from the center of the body to the equator
+
+    semi_minor : float
+                 Radius from the center of the body to the pole
+
+    Returns
+    -------
+    lon : float
+          longitude (in degrees)
+
+    lat : float
+          planetographic latitude (in degrees)
+    """
+
+    lon_oc = np.radians(lon)
+    lat_oc = np.radians(lat)
+
+    proj_str = f"""
+    +proj=pipeline
+    +step +proj=geoc +a={semi_major} +b={semi_minor} +lon_wrap=180 +inv +xy_in=rad +xy_out=rad
+    """
+    oc2og = pyproj.transformer.Transformer.from_pipeline(proj_str)
+    lon_og, lat_og = oc2og.transform(lon_oc, lat_oc, errcheck=True, radians=True)
+
+    return np.degrees(lon_og), np.degrees(lat_og)
 
 def reproject(record, semi_major, semi_minor, source_proj, dest_proj, **kwargs):
     """

--- a/autocnet/transformation/tests/test_spatial.py
+++ b/autocnet/transformation/tests/test_spatial.py
@@ -12,7 +12,7 @@ def test_oc2og():
 def test_og2oc():
     lon = 0
     lat = 20
-    lon_oc, lat_oc = spatial.oc2og(lon, lat, 3396190, 3376200)
+    lon_oc, lat_oc = spatial.og2oc(lon, lat, 3396190, 3376200)
     assert lat_oc == 19.78356596059272
 
 

--- a/autocnet/transformation/tests/test_spatial.py
+++ b/autocnet/transformation/tests/test_spatial.py
@@ -3,6 +3,19 @@ import pytest
 
 from autocnet.transformation import spatial
 
+def test_oc2og():
+    lon = 0
+    lat = 20
+    lon_og, lat_og = spatial.oc2og(lon, lat, 3396190, 3376200)
+    assert lat_og == 20.218400434636393
+
+def test_og2oc():
+    lon = 0
+    lat = 20
+    lon_oc, lat_oc = spatial.oc2og(lon, lat, 3396190, 3376200)
+    assert lat_oc == 19.78356596059272
+
+
 def test_reproject():
     with mock.patch('pyproj.transform', return_value=[1,1,1]) as mock_pyproj:
         res = spatial.reproject([1,1,1], 10, 10, 'geocent', 'latlon')

--- a/autocnet/transformation/tests/test_spatial.py
+++ b/autocnet/transformation/tests/test_spatial.py
@@ -1,5 +1,6 @@
 from unittest import mock
 import pytest
+import math
 
 from autocnet.transformation import spatial
 
@@ -7,13 +8,24 @@ def test_oc2og():
     lon = 0
     lat = 20
     lon_og, lat_og = spatial.oc2og(lon, lat, 3396190, 3376200)
-    assert lat_og == 20.218400434636393
+
+    # calculate lat conversion by hand
+    dlat = math.radians(lat)
+    dlat = math.atan(((3396190 / 3376200)**2) * (math.tan(dlat)))
+    dlat = math.degrees(dlat)
+
+    assert math.isclose(lat_og, dlat)
 
 def test_og2oc():
     lon = 0
     lat = 20
     lon_oc, lat_oc = spatial.og2oc(lon, lat, 3396190, 3376200)
-    assert lat_oc == 19.78356596059272
+
+    dlat = math.radians(lat)
+    dlat = math.atan((math.tan(dlat) / ((3396190 / 3376200)**2)))
+    dlat = math.degrees(dlat)
+
+    assert math.isclose(lat_oc, dlat)
 
 
 def test_reproject():


### PR DESCRIPTION
This allows us to select who many/which points to propagate from one network to another. This is particularly helpful when grounding a network. The initial propagate_control_network call can propagate a single point corresponding to the best match (as defined by geom_match output template metric) between a control network existing in the grounding data to the control data. Then the second propagate_control_network call can propagate that best point (now in the control data image space) to the rest of the overlapping control data images.

During this code change I also added doc strings to the propagation functions and reconciled the use of ographic/ocentric latitudes throughout the code. Autocnet now expects ocentric latitude inputs from the DB geometry columns.