### PR TITLE
typo, 'conda condig' should be 'conda config'

### DIFF
--- a/docs/users/installation.rst
+++ b/docs/users/installation.rst
@@ -13,7 +13,7 @@ Via Conda
   * ``conda create -n <your_environment_name> python=3 && source activate <your_environment_name>``
 1. Bring up a command line and add three channels to your conda config (``~/condarc``):
   * ``conda config --add channels conda-forge``
-  * ``conda condig --add channels jlaura``
+  * ``conda config --add channels jlaura``
   * ``conda config --add channels menpo``
 1. Finally, install autocnet: ``conda install -c jlaura autocnet-dev``
 


### PR DESCRIPTION
bigger issue is that
`> conda install -c jlaura autocnet-dev`
responds
`PackagesNotFoundError:`