### PR TITLE
typo in conda install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We suggest using Anaconda Python to install Autocnet within a virtual environmen
 1. [Download](https://www.continuum.io/downloads) and install the Python 3.x Miniconda installer.  Respond ``Yes`` when prompted to add conda to your BASH profile.  
 2. Install the autocnet environment using the supplied environment.yml file: `conda env create -n autocnet -f environment.yml` 
 3. Activate your environment: `conda activate autocnet`
-4. If you are doing to develop autocnet or would like to use the bleeding edge version: `python setup.py develop`. Otherwise, `conda install -c usgs-astrogeology` autocnet.
+4. If you are doing to develop autocnet or would like to use the bleeding edge version: `python setup.py develop`. Otherwise, `conda install -c usgs-astrogeology autocnet`
 
 ## How to run the test suite locally
 


### PR DESCRIPTION
Regardless of the typo fix, these instructions do not seem to work.

upon following steps 2, 3, and 4 (`conda install -c usgs-astrogeology autocnet`)
I am unable to succesfully use autocnet. 

`> from autocnet.graph.network import NetworkCandidateGraph`  
returns this error  
```
~/anaconda3/envs/autocnet/lib/python3.7/site-packages/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "
~/anaconda3/envs/autocnet/lib/python3.7/site-packages/pysis/env.py:31: RuntimeWarning: Could not find isis. Is `ISISROOT` set?
  warnings.warn('Could not find isis. Is `ISISROOT` set?', RuntimeWarning)
```

What is ISISROOT? Is [the isis package](https://github.com/USGS-Astrogeology/ISIS3#installation) a dependency that I need to download and configure? I can't find the referenced script to configure ISISROOT.

thanks