### PR TITLE
Explicitly sets the redis connection max

### DIFF
--- a/services/redis.conf
+++ b/services/redis.conf
@@ -529,7 +529,7 @@ slave-priority 100
 # Once the limit is reached Redis will close all the new connections sending
 # an error 'max number of clients reached'.
 #
-# maxclients 10000
+maxclients 10000
 
 ############################## MEMORY MANAGEMENT ################################
 


### PR DESCRIPTION
This should not be a CI tested change because I do not believe we use the services/docker-compose in the CI environment.