### PR TITLE
Session cleanup

### DIFF
--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -714,6 +714,9 @@ def subpixel_register_measure(measureid,
 
     result = {'measureid':measureid,
               'status':''}
+    
+    if not ncg.Session:
+        raise BrokenPipeError('This func requires a database session from a NetworkCandidateGraph.')
 
     with ncg.session_scope() as session:
         # Setup the measure that is going to be matched
@@ -792,10 +795,6 @@ def subpixel_register_point(pointid,
 
     Parameters
     ----------
-    ncg : obj
-          the network candidate graph that the point is associated with; used for
-          the DB session that is able to access the point.
-
     pointid : int or obj
               The identifier of the point in the DB or a Points object
 
@@ -814,9 +813,12 @@ def subpixel_register_point(pointid,
     threshold : numeric
                 measures with a cost <= the threshold are marked as ignore=True in
                 the database.
+    ncg : obj
+          the network candidate graph that the point is associated with; used for
+          the DB session that is able to access the point.
     """
-    Session = ncg.Session
-    if not Session:
+
+    if not ncg.Session:
         raise BrokenPipeError('This func requires a database session from a NetworkCandidateGraph.')
 
     if isinstance(pointid, Points):

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -63,8 +63,7 @@ def place_points_in_overlaps(size_threshold=0.0007,
     size_threshold : float
                      overlaps with area <= this threshold are ignored
     """
-    Session = ncg.Session
-    if not Session:
+    if not ncg.Session:
         raise BrokenPipeError('This func requires a database session from a NetworkCandidateGraph.')
 
     for overlap in Overlay.overlapping_larger_than(size_threshold, Session):
@@ -106,8 +105,7 @@ def place_points_in_overlap(overlap,
     points : list of Points
         The list of points seeded in the overlap
     """
-    Session = ncg.Session
-    if not Session:
+    if not ncg.Session:
         raise BrokenPipeError('This func requires a database session from a NetworkCandidateGraph.')
 
     # Determine what sensor type to use

--- a/bin/acn_submit
+++ b/bin/acn_submit
@@ -43,17 +43,21 @@ def _instantiate_row(msg, ncg):
     # Get the dict mapping iterable keyword types to the objects
     objdict = ncg.apply_iterable_options
     rowid = msg['id']
-
-    session = ncg.Session()
     obj = objdict[msg['along']]
-    res = session.query(obj).filter(getattr(obj, 'id')==msg['id']).one()
-    session.close()
+    with ncg.session_scope() as session:
+        res = session.query(obj).filter(getattr(obj, 'id')==msg['id']).one()
+        print(session.execute('SELECT sum(numbackends) FROM pg_stat_database;').scalar())
+        print('Done instantiating the obj')
+        session.expunge(res) # Disconnect the object from the session
     return res
 
 def main(msg):
 
     ncg = NetworkCandidateGraph()
     ncg.config_from_dict(msg['config'])
+    with ncg.session_scope() as session:
+        print(session.execute('SELECT sum(numbackends) FROM pg_stat_database;').scalar())
+    print('Done with backened sum')
 
     if msg['along'] in ['node', 'edge']:
         obj = _instantiate_obj(msg, ncg)
@@ -67,6 +71,8 @@ def main(msg):
     if hasattr(obj, msg['func']): 
         func = getattr(obj, msg['func'])
     else:
+        # In this case, obj is just the integer ID. This is only called for database
+        # related objects.
         func = import_func(msg['func'])
         # Get the object begin processed prepended into the args.
         msg['args'] = (obj, *msg['args'])

--- a/bin/acn_submit
+++ b/bin/acn_submit
@@ -46,8 +46,6 @@ def _instantiate_row(msg, ncg):
     obj = objdict[msg['along']]
     with ncg.session_scope() as session:
         res = session.query(obj).filter(getattr(obj, 'id')==msg['id']).one()
-        print(session.execute('SELECT sum(numbackends) FROM pg_stat_database;').scalar())
-        print('Done instantiating the obj')
         session.expunge(res) # Disconnect the object from the session
     return res
 
@@ -55,9 +53,6 @@ def main(msg):
 
     ncg = NetworkCandidateGraph()
     ncg.config_from_dict(msg['config'])
-    with ncg.session_scope() as session:
-        print(session.execute('SELECT sum(numbackends) FROM pg_stat_database;').scalar())
-    print('Done with backened sum')
 
     if msg['along'] in ['node', 'edge']:
         obj = _instantiate_obj(msg, ncg)
@@ -71,8 +66,6 @@ def main(msg):
     if hasattr(obj, msg['func']): 
         func = getattr(obj, msg['func'])
     else:
-        # In this case, obj is just the integer ID. This is only called for database
-        # related objects.
         func = import_func(msg['func'])
         # Get the object begin processed prepended into the args.
         msg['args'] = (obj, *msg['args'])


### PR DESCRIPTION
These changes ensure that the sessions are being closed properly. I tested this via a notebook. I need to think more about if/how this could be CI tested. Not sure it can be without some pretty significant mocking.

Here is the test I ran:

1. Create an NCG with 2 images
2. Get the current count of number of connections to the db using: 

```
def check_connection_count(ncg):
    with ncg.session_scope() as session:
        num_con = session.execute('SELECT sum(numbackends) FROM pg_stat_database;').scalar()
        #num_con = session.execute('select count(*) from pg_stat_activity;').scalar()

    return num_con
```

3. Confirm that the count is either 1 or 1+any pgadmin connections. To do this cleanly, I stood up a test_db container on smalls so that nothing was colliding with other people working.
4. Print the number of connections, run place points in overlap, and then run the following while place points is happening on the cluster:

```
for i in range(120):
    nconn = check_connection_count(ncgA)
    print(nconn)
    sleep(0.5)
```

results were as expected. One job was running so we had one additional connection.

5. This resulted in 22 points. Then I sub pixel registered these and saw the following:

```
3
3
3
3
3
6
25
25
25
25
25
25
25
25
25
25
25
17
16
3
3
3
3
3
3
```

Since I had pgadmin with one query and the initial NCG sessions live I was expecting to see 25 total connections at the peak. So it looks like the sessions are properly expunging. The repeated 25s (at 0.5 second) intervals look to me like we do not have any additional spurious sessions being created inside of the function call or dangling from acn_submit.

