### PR TITLE
affine centered on the ROI

### DIFF
--- a/autocnet/matcher/cross_instrument_matcher.py
+++ b/autocnet/matcher/cross_instrument_matcher.py
@@ -267,7 +267,6 @@ def propagate_point(Session,
         sx, sy = m["sample"], m["line"]
 
         for i,image in images.iterrows():
-            print('PATH', image['path'])
             # When grounding to THEMIS the df has a PATH to the QUAD
             dest_image = GeoDataset(image["path"])
 

--- a/autocnet/matcher/cross_instrument_matcher.py
+++ b/autocnet/matcher/cross_instrument_matcher.py
@@ -105,8 +105,12 @@ def generate_ground_points(Session, ground_mosaic, nspts_func=lambda x: int(roun
         # res = ground_session.execute(formated_sql)
         p = Point(*coord)
         print(f'point {i}'),
-
+ 
+        
         linessamples = isis.point_info(ground_mosaic.file_name, p.x, p.y, 'ground')
+        if linessamples is None:
+            print('unable to find point in ground image')
+            continue
         line = linessamples[0].get('Line')
         sample = linessamples[0].get('Sample')
 
@@ -259,10 +263,12 @@ def propagate_point(Session,
     # lazily iterate for now
     for k,m in image_measures.iterrows():
         base_image = GeoDataset(m["path"])
-
+        
         sx, sy = m["sample"], m["line"]
 
         for i,image in images.iterrows():
+            print('PATH', image['path'])
+            # When grounding to THEMIS the df has a PATH to the QUAD
             dest_image = GeoDataset(image["path"])
 
             if os.path.basename(m['path']) == os.path.basename(image['path']):
@@ -273,7 +279,6 @@ def propagate_point(Session,
                 print(f'prop point: dest_image: {dest_image}')
                 print(f'prop point: (sx, sy): ({sx}, {sy})')
                 x,y, dist, metrics, corrmap = geom_match(base_image, dest_image, sx, sy, \
-                        size_x=size_x, size_y=size_y, \
                         template_kwargs=template_kwargs, \
                         verbose=verbose)
             except Exception as e:
@@ -431,7 +436,7 @@ def propagate_control_network(Session,
         if len(gp_measures) == 0:
             continue
         constrained_net.extend(gp_measures)
-
+        
     ground = gpd.GeoDataFrame.from_dict(constrained_net).set_geometry('point')
     groundpoints = ground.groupby('pointid').groups
 

--- a/autocnet/matcher/naive_template.py
+++ b/autocnet/matcher/naive_template.py
@@ -85,7 +85,7 @@ def pattern_match_autoreg(template, image, subpixel_size=3, max_scaler=0.2, func
 
     return x, y, max_corr
 
-def pattern_match(template, image, upsampling=16, func=cv2.TM_CCOEFF_NORMED, error_check=False):
+def pattern_match(template, image, upsampling=16, metric=cv2.TM_CCOEFF_NORMED, error_check=False):
     """
     Call an arbitrary pattern matcher using a subpixel approach where the template and image
     are upsampled using a third order polynomial.
@@ -135,10 +135,10 @@ def pattern_match(template, image, upsampling=16, func=cv2.TM_CCOEFF_NORMED, err
         u_template = template
         u_image = image
 
-    result = cv2.matchTemplate(u_image, u_template, method=func)
+    result = cv2.matchTemplate(u_image, u_template, method=metric)
     _, max_corr, min_loc, max_loc = cv2.minMaxLoc(result)
 
-    if func == cv2.TM_SQDIFF or func == cv2.TM_SQDIFF_NORMED:
+    if metric == cv2.TM_SQDIFF or metric == cv2.TM_SQDIFF_NORMED:
         x, y = (min_loc[0], min_loc[1])
     else:
         x, y = (max_loc[0], max_loc[1])

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -3,7 +3,6 @@ from math import modf, floor
 import numpy as np
 
 from skimage.feature import register_translation
-
 from skimage import transform as tf
 
 from matplotlib import pyplot as plt
@@ -227,12 +226,159 @@ def subpixel_phase(sx, sy, dx, dy,
 
     return dx, dy, (error, diffphase)
 
+def subpixel_transformed_template(sx, sy, dx, dy,
+                                  s_img, d_img,
+                                  transform,
+                                  image_size=(251, 251),
+                                  template_size=(51, 51),
+                                  template_buffer=5,
+                                  func=pattern_match,
+                                  verbose=False,
+                                  **kwargs):
+    """
+    Uses a pattern-matcher on subsets of two images determined from the passed-in keypoints and optional sizes to
+    compute an x and y offset from the search keypoint to the template keypoint and an associated strength.
+
+    Parameters
+    ----------
+    sx : Numeric
+         Source X coordinate
+
+    sy : Numeric
+         Source y coordinate
+
+    dx : Numeric
+         The desintation x coordinate
+
+    dy : Numeric
+         The destination y coordinate
+
+    s_img : GeoDataset
+            The source image GeoDataset
+
+    d_img : GeoDataset
+            The destination image GeoDataset
+
+    transform : object
+                A skiage transform object that has scale. The transform object is
+                used to project the template into the image.
+
+    image_size : tuple
+                 (xsize, ysize) of the image that is searched within (this should be larger
+                 than the template size)
+
+    template_size : tuple
+                    (xsize, ysize) of the template to iterate over the image in order
+                    to identify the area(s) of highest correlation.
+
+    template_buffer : int
+                      The inverse buffer applied to the transformed template image. When
+                      the warp is applied to project from the template into the image, some
+                      amount of no data exists around the edges. This variable is used to clip
+                      some number of pixels off the edges of the template. The higher the rotation
+                      the higher this value should be.
+
+    func : callable
+           The function used to pattern match
+
+    verbose : bool
+              If true, generate plots of the matches
+
+    Returns
+    -------
+    x_shift : float
+               Shift in the x-dimension
+
+    y_shift : float
+               Shift in the y-dimension
+
+    strength : float
+               Strength of the correspondence in the range [-1, 1]
+
+    corrmap : ndarray
+              An n,m array of correlation coefficients
+
+    See Also
+    --------
+    autocnet.matcher.naive_template.pattern_match : for the kwargs that can be passed to the matcher
+    autocnet.matcher.naive_template.pattern_match_autoreg : for the jwargs that can be passed to the autoreg style matcher
+    """                           
+    image_size = check_image_size(image_size)
+    template_size = check_image_size(template_size)
+    
+    template_size_x = template_size[0] * transform.scale[0]
+    template_size_y = template_size[1] * transform.scale[1]
+
+    s_roi = roi.Roi(s_img, sx, sy, size_x=image_size[0], size_y=image_size[1])
+    d_roi = roi.Roi(d_img, dx, dy, size_x=template_size_x, size_y=template_size_y)
+
+    try:
+        s_image_dtype = isis2np_types[pvl.load(s_img.file_name)["IsisCube"]["Core"]["Pixels"]["Type"]]
+    except:
+        s_image_dtype = None
+    
+    try:
+        d_template_dtype = isis2np_types[pvl.load(d_img.file_name)["IsisCube"]["Core"]["Pixels"]["Type"]]
+    except:
+        d_template_dtype = None
+
+    s_image = bytescale(s_roi.clip(dtype=s_image_dtype))
+    d_template = bytescale(d_roi.clip(dtype=d_template_dtype))
+
+    # Build the transformation chance
+    shift_x, shift_y = d_roi.center
+    
+    tf_rotate = tf.AffineTransform(rotation=transform.rotation, shear=transform.shear)
+    tf_shift = tf.SimilarityTransform(translation=[-shift_x, -shift_y])
+    tf_shift_inv = tf.SimilarityTransform(translation=[shift_x, shift_y])
+
+    # Define the full chain and the inverse
+    trans = (tf_shift + (tf_rotate + tf_shift_inv))
+    itrans = trans.inverse
+
+    # Now apply the affine transformation
+    transformed_roi = tf.warp(d_template,
+                                itrans,
+                                order=3)
+
+    # Scale the CTX arr to the proper size
+    scale_y, scale_x = transform.scale
+    template_shape_y, template_shape_x = d_template.shape
+
+    scaled_roi = tf.resize(transformed_roi, (int(template_shape_x/scale_x), int(template_shape_y/scale_x)))
+    d_template = bytescale(scaled_roi)
+    
+    # Clip the transformed template to avoid no data around around the edges
+    buffered_template = d_template[template_buffer:-template_buffer,template_buffer:-template_buffer]
+
+    # Apply the matcher on the transformed array
+    shift_x, shift_y, metrics, corrmap = func(buffered_template, s_image, **kwargs)
+
+    # Project the center into the affine space
+    projected_center = itrans(d_roi.center)[0]
+
+    # Shifts need to be scaled back into full resolution, affine space
+    shift_x *= scale_x
+    shift_y *= scale_y
+
+    # Apply the shifts (computed using the warped image) to the affine space center
+    new_projected_x = projected_center[0] - shift_x
+    new_projected_y = projected_center[1] - shift_y
+
+    # Project the updated location back into image space
+    new_unprojected_x, new_unprojected_y = trans([new_projected_x, new_projected_y])[0]
+
+    # Apply the shift
+    dx = d_roi.x - (d_roi.center[0] - new_unprojected_x)
+    dy = d_roi.y - (d_roi.center[1] - new_unprojected_y)
+
+    return dx, dy, metrics, corrmap
+
 def subpixel_template(sx, sy, dx, dy,
                       s_img, d_img,
                       image_size=(251, 251),
                       template_size=(51,51),
                       func=pattern_match,
-                      transform = None,
                       verbose=False,
                       **kwargs):
     """
@@ -266,6 +412,12 @@ def subpixel_template(sx, sy, dx, dy,
     template_size : tuple
                     (xsize, ysize) of the template to iterate over the image in order
                     to identify the area(s) of highest correlation.
+    
+    func : callable
+           The function used to pattern match
+
+    verbose : bool
+              If true, generate plots of the matches
 
     Returns
     -------
@@ -278,6 +430,9 @@ def subpixel_template(sx, sy, dx, dy,
     strength : float
                Strength of the correspondence in the range [-1, 1]
 
+    corrmap : ndarray
+              An n,m array of correlation coefficients
+
     See Also
     --------
     autocnet.matcher.naive_template.pattern_match : for the kwargs that can be passed to the matcher
@@ -286,12 +441,8 @@ def subpixel_template(sx, sy, dx, dy,
     image_size = check_image_size(image_size)
     template_size = check_image_size(template_size)
 
-    if transform:
-        template_size_x = template_size[0] * transform.scale[0]
-        template_size_y = template_size[1] * transform.scale[1]
-    else:
-        template_size_x = template_size[0]
-        template_size_y = template_size[1]
+    template_size_x = template_size[0]
+    template_size_y = template_size[1]
 
     s_roi = roi.Roi(s_img, sx, sy, size_x=image_size[0], size_y=image_size[1])
     d_roi = roi.Roi(d_img, dx, dy, size_x=template_size_x, size_y=template_size_y)
@@ -314,31 +465,7 @@ def subpixel_template(sx, sy, dx, dy,
          axs[0].imshow(s_image, cmap='Greys')
          axs[1].imshow(d_template, cmap='Greys')
 
-    if transform:
-        # Build the transformation chance
-        shift_x, shift_y = d_roi.center
-        
-        tf_rotate = tf.AffineTransform(rotation=transform.rotation, shear=transform.shear)
-        tf_shift = tf.SimilarityTransform(translation=[-shift_x, -shift_y])
-        tf_shift_inv = tf.SimilarityTransform(translation=[shift_x, shift_y])
-
-        # Define the full chain and the inverse
-        trans = (tf_shift + (tf_rotate + tf_shift_inv))
-        itrans = trans.inverse
-
-        # Now apply the affine transformation
-        transformed_roi = tf.warp(d_template,
-                                  itrans,
-                                  order=3)
-
-        # Scale the CTX arr to the proper size
-        scale_y, scale_x = transform.scale
-        template_shape_y, template_shape_x = d_template.shape
-
-        scaled_roi = tf.resize(transformed_roi, (int(template_shape_x/scale_x), int(template_shape_y/scale_x)))
-        d_template = bytescale(scaled_roi)
-    else:
-        transformed_roi = d_template
+    transformed_roi = d_template
 
     if verbose:
         axs[2].imshow(transformed_roi, cmap='Greys')
@@ -349,28 +476,12 @@ def subpixel_template(sx, sy, dx, dy,
     if (s_image is None) or (d_template is None):
         return None, None, None, None
 
-    shift_x, shift_y, metrics, corrmap = func(d_template[5:-5,5:-5], s_image, **kwargs)
+    # Apply the matcher function
+    shift_x, shift_y, metrics, corrmap = func(d_template, s_image, **kwargs)
 
-    if transform:
-        # Project the center into the affine space
-        projected_center = itrans(d_roi.center)[0]
-
-        # Shifts need to be scaled back into full resolution, affine space
-        shift_x *= scale_x
-        shift_y *= scale_y
-
-        # Apply the shifts (computed using the warped image) to the affine space center
-        new_projected_x = projected_center[0] - shift_x
-        new_projected_y = projected_center[1] - shift_y
-
-        # Project the updated location back into image space
-        new_unprojected_x, new_unprojected_y = trans([new_projected_x, new_projected_y])[0]
-
-        dx = d_roi.x - (d_roi.center[0] - new_unprojected_x)
-        dy = d_roi.y - (d_roi.center[1] - new_unprojected_y)
-    else:
-        dx = d_roi.x - shift_x
-        dy = d_roi.y - shift_y
+    # Apply the shift to the center of the ROI object
+    dx = d_roi.x - shift_x
+    dy = d_roi.y - shift_y
 
     return dx, dy, metrics, corrmap
 
@@ -565,7 +676,6 @@ def geom_match(base_cube,
                 measure's location in the base subimage and the unprojected destination subimage with the corresponding
                 template metric correlation map.
 
-
     Returns
     -------
     sample: int
@@ -655,106 +765,20 @@ def geom_match(base_cube,
     # Estimate the transformation
     affine = estimate_affine_transformation(base_corners, dst_corners)
 
-    # Constant THEMIS scales.
-    # Multiple CTX by the scale to make it all big and such
-    restemplate = subpixel_template(bcenter_x, bcenter_y, 
-                                    center_x, center_y, 
-                                    base_cube, input_cube, 
-                                    transform=affine,
-                                    verbose=verbose,
-                                    **template_kwargs)
+    # Apply the subpixel matcher with an affine transformation
+    restemplate = subpixel_transformed_template(bcenter_x, bcenter_y, 
+                                                center_x, center_y, 
+                                                base_cube, input_cube, 
+                                                affine,
+                                                verbose=verbose,
+                                                **template_kwargs)
 
-    if phase_kwargs:
-        _,_,maxcorr, temp_corrmap = restemplate
-        sample_template, line_template = affine([restemplate[0], restemplate[1]])[0]
-        sample_template += start_x
-        line_template += start_y
-        dist_temp = np.linalg.norm([center_x-sample_template, center_y-line_template])
+    x,y,maxcorr,temp_corrmap = restemplate
+    
+    if x is None or y is None:
+        return None, None, None, None, None
 
-        resphase = subpixel_phase(size_x, size_y, restemplate[0], restemplate[1], base_arr, dst_arr, **phase_kwargs)
-        x,y,(perror, pdiff) = resphase
-        if x is None or y is None:
-            return None, None, None, None, None
-        sample, line = affine([x, y])[0]
-        sample += start_x
-        line += start_y
-        phase_dist = np.linalg.norm([sample_template-sample, line_template-line])
-
-        dist = (dist_temp, dist_phase)
-        metric = (maxcorr, perror, pdiff)
-    else:
-        x,y,maxcorr,temp_corrmap = restemplate
-        
-        if x is None or y is None:
-            return None, None, None, None, None
-        
-        if verbose:
-            image_size = template_kwargs['image_size']
-            template_size = template_kwargs['template_size']
-            image_size = check_image_size(image_size)
-            template_size = check_image_size(template_size)
-            image_chip = roi.Roi(base_cube, bcenter_x, bcenter_y, size_x=image_size[0], size_y=image_size[1]).clip()
-            temp_chip = roi.Roi(input_cube, x, y, size_x=template_size[0], size_y=template_size[1]).clip()
-            fig, axs = plt.subplots(1, 3, figsize=(15,15))
-            axs[0].set_title("Image Chip")
-            axs[0].imshow(bytescale(image_chip), cmap="Greys_r")
-            axs[1].set_title("Template Chip")
-            axs[1].imshow(bytescale(temp_chip), cmap="Greys_r")
-            print(temp_corrmap.shape)
-            pcm = axs[2].imshow(temp_corrmap**2, interpolation=None, cmap="coolwarm")
-            plt.show()
-
-            fig, axs = plt.subplots(1, 3, figsize=(15,15))
-            axs[0].set_title("Base")
-            axs[0].imshow(bytescale(base_arr), cmap="Greys_r")
-            axs[0].scatter(size_x, size_y, s=10, color='red')
-            axs[0].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
-            axs[0].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
-            #axs[0].set_xlim([0, base_arr.shape[0]])
-            #axs[0].set_ylim([0, base_arr.shape[1]])
-            axs[1].set_title("Unprojected Image\n w/ original point")
-            dst_arr = input_cube.read_array(pixels=dst_pixels, dtype=dst_type)
-            axs[1].imshow(bytescale(dst_arr), cmap="Greys_r")
-            #axs[1].scatter(warped_center_x, warped_center_y, s=10, color='blue')
-            nx, ny = affine([x,y])[0]
-            ox, oy = affine(warped_center)[0]
-            print(nx, ny)
-            axs[1].scatter(nx, ny, s=10, color='red')
-            axs[1].scatter(ox, oy, s=10, color='blue')
-            #axs[1].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
-            #axs[1].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
-            #axs[1].set_xlim([0, dst_arr[2:].shape[0]])
-            #axs[1].set_ylim([0, dst_arr[2:].shape[1]])
-            axs[2].set_title("Projected Image\n w/ registered point")
-            axs[2].imshow(bytescale(dst_arr[2:]), cmap="Greys_r")
-            axs[2].scatter(x, y, s=10, color='red')
-            axs[2].plot([0, size_x*2], [y, y], linewidth=0.75, color='red')
-            axs[2].plot([x, x], [0, size_y*2], linewidth=0.75, color='red')
-            #axs[2].set_xlim([0, dst_arr[2:].shape[0]])
-            #axs[2].set_ylim([0, dst_arr[2:].shape[1]])
-
-            plt.show()
-
-        dist = np.linalg.norm([center_x-x, center_y-y])
-        print('DIST', dist)
-        """if verbose:
-            fig, axs = plt.subplots(1, 2, figsize=(10,5))
-            # clip the image around the new line, sample
-            new_size_x = round(size_x*100/6) # 100/6 is a scaling between tehmis and CTX resolution
-            new_size_y = round(size_y*100/6)
-            new_dst_arr = roi.Roi(input_cube, sample, line, size_x=new_size_x, size_y=new_size_y).clip()
-            axs[0].imshow(new_dst_arr, cmap='Greys_r');
-            axs[0].scatter(new_size_x, new_size_y, s=10, color='red');
-            axs[0].set_title("Absolute\n Unprojected Image \nw/ registered point");
-
-            dst_arr_org = input_cube.read_array(pixels=dst_pixels, dtype=dst_type)
-            ssample, lline = affine([x, y])[0]
-            axs[1].imshow(dst_arr_org, cmap="Greys_r")
-            axs[1].scatter(ssample, lline, s=10, color='blue')
-            axs[1].set_title("Relative\n Unprojected Image\nw/registered point")
-            plt.show()"""
-
-
+    dist = np.linalg.norm([center_x-x, center_y-y])
     return x, y, dist, metric, temp_corrmap
 
 

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -24,6 +24,12 @@ import pandas as pd
 
 import pvl
 
+isis2np_types = {
+        "UnsignedByte" : "uint8",
+        "SignedWord" : "int16",
+        "Real" : "float64"
+}
+
 # TODO: look into KeyPoint.size and perhaps use to determine an appropriately-sized search/template.
 def _prep_subpixel(nmatches, nstrengths=2):
     """
@@ -148,7 +154,6 @@ def clip_roi(img, center_x, center_y, size_x=200, size_y=200, dtype="uint64"):
             return None, 0, 0
     return subarray, axr, ayr
 
-
 def subpixel_phase(sx, sy, dx, dy,
                    s_img, d_img,
                    image_size=(51, 51),
@@ -227,6 +232,7 @@ def subpixel_template(sx, sy, dx, dy,
                       image_size=(251, 251),
                       template_size=(51,51),
                       func=pattern_match,
+                      transform = None,
                       **kwargs):
     """
     Uses a pattern-matcher on subsets of two images determined from the passed-in keypoints and optional sizes to
@@ -276,24 +282,103 @@ def subpixel_template(sx, sy, dx, dy,
     autocnet.matcher.naive_template.pattern_match : for the kwargs that can be passed to the matcher
     autocnet.matcher.naive_template.pattern_match_autoreg : for the jwargs that can be passed to the autoreg style matcher
     """
-
     image_size = check_image_size(image_size)
     template_size = check_image_size(template_size)
 
+    ox = dx
+    oy = dy
+
     s_roi = roi.Roi(s_img, sx, sy, size_x=image_size[0], size_y=image_size[1])
-    d_roi = roi.Roi(d_img, dx, dy, size_x=template_size[0], size_y=template_size[1])
+    d_roi = roi.Roi(d_img, dx, dy, size_x=template_size[0] * transform.scale[0], size_y=template_size[1] * transform.scale[1])
 
-    s_image = s_roi.clip()
-    d_template = d_roi.clip()
+    try:
+        s_image_dtype = isis2np_types[pvl.load(s_img.file_name)["IsisCube"]["Core"]["Pixels"]["Type"]]
+    except:
+        s_image_dtype = None
+    
+    try:
+        d_template_dtype = isis2np_types[pvl.load(d_img.file_name)["IsisCube"]["Core"]["Pixels"]["Type"]]
+    except:
+        d_template_dtype = None
 
+    s_image = bytescale(s_roi.clip(dtype=s_image_dtype))
+    d_template = bytescale(d_roi.clip(dtype=d_template_dtype))
+    
+    fig, axs = plt.subplots(1, 5, figsize=(20,10))
+    axs[0].imshow(s_image, cmap='Greys')
+    axs[1].imshow(d_template, cmap='Greys')
+
+    if transform:
+        # Build the transformation chance
+        shift_x, shift_y = d_roi.center
+        
+        tf_rotate = tf.AffineTransform(rotation=transform.rotation, shear=transform.shear)
+        tf_shift = tf.SimilarityTransform(translation=[-shift_x, -shift_y])
+        tf_shift_inv = tf.SimilarityTransform(translation=[shift_x, shift_y])
+
+        # Define the full chain and the inverse
+        trans = (tf_shift + (tf_rotate + tf_shift_inv))
+        itrans = trans.inverse
+
+        # Now apply the affine transformation
+        transformed_roi = tf.warp(d_template,
+                                  itrans,
+                                  order=3)
+
+        # Scale the CTX arr to the proper size
+        scale_y, scale_x = transform.scale
+        template_shape_y, template_shape_x = d_template.shape
+
+        scaled_roi = tf.resize(transformed_roi, (int(template_shape_x/scale_x), int(template_shape_y/scale_x)))
+        d_template = bytescale(scaled_roi)
+
+    #from skimage.exposure import match_histograms
+    #matched = match_histograms(bytescale(scaled_ctx), s_image)
+    #matched = bytescale(matched)
+    #matched = bytescale(scaled_ctx)
+
+    axs[2].imshow(transformed_roi, cmap='Greys')
+    axs[3].imshow(d_template[5:-5,5:-5], cmap='Greys')
+    
     if (s_image is None) or (d_template is None):
         return None, None, None, None
 
-    shift_x, shift_y, metrics, corrmap = func(d_template, s_image, **kwargs)
+    shift_x, shift_y, metrics, corrmap = func(d_template[5:-5,5:-5], s_image, **kwargs)
 
-    dx = d_roi.x - shift_x
-    dy = d_roi.y - shift_y
+    if transform:
+        # Project the center into the affine space
+        projected_center = itrans(d_roi.center)[0]
+        print('roi center', d_roi.center)
+        print(projected_center)
+        
+        # Shifts need to be scaled back into full resolution, affine space
+        shift_x *= scale_x
+        shift_y *= scale_y
+        print('shifts', shift_x, shift_y)
 
+        # Apply the shifts (computed using the warped image) to the affine space center
+        new_projected_x = projected_center[0] - shift_x
+        new_projected_y = projected_center[1] - shift_y
+        
+        print('new x, y in proj space', new_projected_x, new_projected_y)
+
+        # Project the updated location back into image space
+        new_unprojected_x, new_unprojected_y = trans([new_projected_x, new_projected_y])[0]
+        print('new xy in unproj (roi) space', new_unprojected_x, new_unprojected_y)
+
+        dx = d_roi.x - (d_roi.center[0] - new_unprojected_x)
+        dy = d_roi.y - (d_roi.center[1] - new_unprojected_y)
+        print('now in full images space', dx, dy)
+    else:
+        dx = d_roi.x - shift_x
+        dy = d_roi.y - shift_y
+
+
+
+    axs[4].imshow(corrmap)
+    plt.show()
+
+    print('How far?',ox, oy, dx, dy, metrics)
     return dx, dy, metrics, corrmap
 
 def subpixel_ciratefi(sx, sy, dx, dy, s_img, d_img, search_size=251, template_size=51, **kwargs):
@@ -417,13 +502,34 @@ def iterative_phase(sx, sy, dx, dy, s_img, d_img, size=(51, 51), reduction=11, c
            break
     return dx, dy, metrics
 
+def estimate_affine_transformation(destination_coordinates, source_coordinates):
+    """
+    Given a set of destination control points compute the affine transformation
+    required to project the source control points into the destination.
+
+    Parameters
+    ----------
+    destination_coordinates : array-like
+                              An n,2 data structure containing the destination control points
+
+    source_coordinates : array-like
+                         An n,2 data structure containing the source control points
+
+    Returns
+    -------
+     : object
+       An skimage affine transform object
+    """
+    destination_coordinates = np.asarray(destination_coordinates)
+    source_coordinates = np.asarray(source_coordinates)
+
+    return tf.estimate_transform('affine', destination_coordinates, source_coordinates)
+
 
 def geom_match(base_cube,
                input_cube,
                bcenter_x,
                bcenter_y,
-               size_x=60,
-               size_y=60,
                template_kwargs={"image_size":(59,59), "template_size":(31,31)},
                phase_kwargs=None,
                verbose=True):
@@ -501,10 +607,14 @@ def geom_match(base_cube,
     if not isinstance(base_cube, GeoDataset):
         raise Exception("match cube must be a geodataset obj")
 
-    base_startx = int(bcenter_x - size_x)
-    base_starty = int(bcenter_y - size_y)
-    base_stopx = int(bcenter_x + size_x)
-    base_stopy = int(bcenter_y + size_y)
+    # Can we validate this inside the ROI object?
+    base_size_x = template_kwargs['image_size'][0]
+    base_size_y = template_kwargs['image_size'][1]
+
+    base_startx = int(bcenter_x - base_size_x)
+    base_starty = int(bcenter_y - base_size_y)
+    base_stopx = int(bcenter_x + base_size_x)
+    base_stopy = int(bcenter_y + base_size_y)
 
     image_size = input_cube.raster_size
     match_size = base_cube.raster_size
@@ -519,23 +629,25 @@ def geom_match(base_cube,
     if base_starty < 0:
         raise Exception(f"Window: {base_starty} < 0, center: {bcenter_x},{bcenter_y}")
 
+    base_corners = [(base_startx,base_starty),
+                    (base_startx,base_stopy),
+                    (base_stopx,base_stopy),
+                    (base_stopx,base_starty)]
+
     # specifically not putting this in a try/except, this should never fail
     # 07/28 - putting it in a try/except because of how we ground points
+    # Transform from the base center to the input_cube center
     try:
         mlat, mlon = spatial.isis.image_to_ground(base_cube.file_name, bcenter_x, bcenter_y)
-        center_x, center_y = spatial.isis.ground_to_image(input_cube.file_name, mlon, mlat)
+        center_y, center_x = spatial.isis.ground_to_image(input_cube.file_name, mlon, mlat)
     except ProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest center located at ({mlon}, {mlat}) does not project to image {input_cube.base_name}')
                 print('This should only appear when propagating ground points')
                 return None, None, None, None, None
 
-
-    base_corners = [(base_startx,base_starty),
-                    (base_startx,base_stopy),
-                    (base_stopx,base_stopy),
-                    (base_stopx,base_starty)]
-
+    # Compute the mapping between the base corners and the input_cube corners in
+    # order to estimate an affine transformation
     dst_corners = []
     for x,y in base_corners:
         try:
@@ -546,40 +658,17 @@ def geom_match(base_cube,
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {input_cube.base_name}')
                 return None, None, None, None, None
 
-    base_gcps = np.array([*base_corners])
-    base_gcps[:,0] -= base_startx
-    base_gcps[:,1] -= base_starty
 
-    dst_gcps = np.array([*dst_corners])
-    start_x = dst_gcps[:,0].min()
-    start_y = dst_gcps[:,1].min()
-    stop_x = dst_gcps[:,0].max()
-    stop_y = dst_gcps[:,1].max()
-    dst_gcps[:,0] -= start_x
-    dst_gcps[:,1] -= start_y
+    # Estimate the transformation
+    affine = estimate_affine_transformation(base_corners, dst_corners)
 
-    affine = tf.estimate_transform('affine', np.array([*base_gcps]), np.array([*dst_gcps]))
-
-    # read_array not getting correct type by default
-    isis2np_types = {
-            "UnsignedByte" : "uint8",
-            "SignedWord" : "int16",
-            "Real" : "float64"
-    }
-
-    base_pixels = list(map(int, [base_corners[0][0], base_corners[0][1], size_x*2, size_y*2]))
-    base_type = isis2np_types[pvl.load(base_cube.file_name)["IsisCube"]["Core"]["Pixels"]["Type"]]
-    base_arr = base_cube.read_array(pixels=base_pixels, dtype=base_type)
-
-    dst_pixels = list(map(int, [start_x, start_y, stop_x-start_x, stop_y-start_y]))
-    dst_type = isis2np_types[pvl.load(input_cube.file_name)["IsisCube"]["Core"]["Pixels"]["Type"]]
-    dst_arr = input_cube.read_array(pixels=dst_pixels, dtype=dst_type)
-
-    dst_arr = tf.warp(dst_arr, affine)
-    dst_arr = dst_arr[:size_y*2, :size_x*2]
-
-    # Run through one step of template matching then one step of phase matching
-    restemplate = subpixel_template(size_x, size_y, size_x, size_y, bytescale(base_arr), bytescale(dst_arr), **template_kwargs)
+    # Constant THEMIS scales.
+    # Multiple CTX by the scale to make it all big and such
+    restemplate = subpixel_template(bcenter_x, bcenter_y, 
+                                    center_x, center_y, 
+                                    base_cube, input_cube, 
+                                    transform=affine,
+                                    **template_kwargs)
 
     if phase_kwargs:
         _,_,maxcorr, temp_corrmap = restemplate
@@ -600,57 +689,65 @@ def geom_match(base_cube,
         dist = (dist_temp, dist_phase)
         metric = (maxcorr, perror, pdiff)
     else:
-        x,y,maxcorr,temp_corrmap = restemplate
+        x,y,metric,temp_corrmap = restemplate
+        
         if x is None or y is None:
             return None, None, None, None, None
+        
         if verbose:
             image_size = template_kwargs['image_size']
             template_size = template_kwargs['template_size']
             image_size = check_image_size(image_size)
             template_size = check_image_size(template_size)
-            image_chip = roi.Roi(bytescale(base_arr), size_x, size_y, size_x=image_size[0], size_y=image_size[1]).clip()
-            temp_chip = roi.Roi(bytescale(dst_arr), size_x, size_y, size_x=template_size[0], size_y=template_size[1]).clip()
+            image_chip = roi.Roi(base_cube, bcenter_x, bcenter_y, size_x=image_size[0], size_y=image_size[1]).clip()
+            image_chip += 128  # Is this signed 8bit? huh?
+            temp_chip = roi.Roi(input_cube, x, y, size_x=template_size[0]*affine.scale[0], size_y=template_size[1]*affine.scale[1]).clip()
             fig, axs = plt.subplots(1, 3, figsize=(15,15))
             axs[0].set_title("Image Chip")
-            axs[0].imshow(bytescale(image_chip), cmap="Greys_r")
+            axs[0].imshow(image_chip, cmap="Greys_r")
+            chip_size = image_chip.shape
+            axs[0].plot(chip_size[1]/2, chip_size[0]/2, 'ro')
             axs[1].set_title("Template Chip")
             axs[1].imshow(bytescale(temp_chip), cmap="Greys_r")
+            temp_size = temp_chip.shape
+            axs[1].plot(temp_size[1]/2, temp_size[0]/2, 'ro')
             pcm = axs[2].imshow(temp_corrmap**2, interpolation=None, cmap="coolwarm")
             plt.show()
 
-            fig, axs = plt.subplots(1, 3, figsize=(15,15))
+            """fig, axs = plt.subplots(1, 3, figsize=(15,15))
             axs[0].set_title("Base")
             axs[0].imshow(bytescale(base_arr), cmap="Greys_r")
             axs[0].scatter(size_x, size_y, s=10, color='red')
             axs[0].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
             axs[0].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
-            axs[0].set_xlim([0, base_arr.shape[0]])
-            axs[0].set_ylim([0, base_arr.shape[1]])
-            axs[1].set_title("Projected Image\n w/ original point")
-            axs[1].imshow(bytescale(dst_arr[2:]), cmap="Greys_r")
-            axs[1].scatter(size_x, size_y, s=10, color='red')
-            axs[1].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
-            axs[1].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
-            axs[1].set_xlim([0, dst_arr[2:].shape[0]])
-            axs[1].set_ylim([0, dst_arr[2:].shape[1]])
+            #axs[0].set_xlim([0, base_arr.shape[0]])
+            #axs[0].set_ylim([0, base_arr.shape[1]])
+            axs[1].set_title("Unprojected Image\n w/ original point")
+            dst_arr = input_cube.read_array(pixels=dst_pixels, dtype=dst_type)
+            axs[1].imshow(bytescale(dst_arr), cmap="Greys_r")
+            #axs[1].scatter(warped_center_x, warped_center_y, s=10, color='blue')
+            nx, ny = affine([x,y])[0]
+            ox, oy = affine(warped_center)[0]
+            print(nx, ny)
+            axs[1].scatter(nx, ny, s=10, color='red')
+            axs[1].scatter(ox, oy, s=10, color='blue')
+            #axs[1].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
+            #axs[1].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
+            #axs[1].set_xlim([0, dst_arr[2:].shape[0]])
+            #axs[1].set_ylim([0, dst_arr[2:].shape[1]])
             axs[2].set_title("Projected Image\n w/ registered point")
             axs[2].imshow(bytescale(dst_arr[2:]), cmap="Greys_r")
             axs[2].scatter(x, y, s=10, color='red')
             axs[2].plot([0, size_x*2], [y, y], linewidth=0.75, color='red')
             axs[2].plot([x, x], [0, size_y*2], linewidth=0.75, color='red')
-            axs[2].set_xlim([0, dst_arr[2:].shape[0]])
-            axs[2].set_ylim([0, dst_arr[2:].shape[1]])
+            #axs[2].set_xlim([0, dst_arr[2:].shape[0]])
+            #axs[2].set_ylim([0, dst_arr[2:].shape[1]])
 
-            plt.show()
+            plt.show()"""
 
-
-        metric = maxcorr
-        sample, line = affine([x, y])[0]
-        sample += start_x
-        line += start_y
-        dist = np.linalg.norm([center_x-sample, center_y-line])
-
-        if verbose:
+        dist = np.linalg.norm([center_x-x, center_y-y])
+        print('DIST', dist)
+        """if verbose:
             fig, axs = plt.subplots(1, 2, figsize=(10,5))
             # clip the image around the new line, sample
             new_size_x = round(size_x*100/6) # 100/6 is a scaling between tehmis and CTX resolution
@@ -665,10 +762,10 @@ def geom_match(base_cube,
             axs[1].imshow(dst_arr_org, cmap="Greys_r")
             axs[1].scatter(ssample, lline, s=10, color='blue')
             axs[1].set_title("Relative\n Unprojected Image\nw/registered point")
-            plt.show()
+            plt.show()"""
 
 
-    return sample, line, dist, metric, temp_corrmap
+    return x, y, dist, metric, temp_corrmap
 
 
 def subpixel_register_measure(measureid,
@@ -706,8 +803,6 @@ def subpixel_register_measure(measureid,
                 measures with a cost <= the threshold are marked as ignore=True in
                 the database.
     """
-
-
 
     if isinstance(measureid, Measures):
         measureid = measureid.id

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -656,10 +656,10 @@ def geom_match(destination_cube,
     Parameters
     ----------
     destination_cube:  plio.io.io_gdal.GeoDataset
-                source image
+                       The image to be matched to
 
-    sourcecube: plio.io.io_gdal.GeoDataset
-                destination image; gets matched to the source image
+    source_cube: plio.io.io_gdal.GeoDataset
+                 The image that is transformed and matched into the destination_cube
 
     bcenter_x:  int
                 sample location of source measure in base_cube
@@ -719,7 +719,6 @@ def geom_match(destination_cube,
     if not isinstance(destination_cube, GeoDataset):
         raise Exception("destination cube must be a geodataset obj")
 
-    # Can we validate this inside the ROI object?
     destination_size_x = template_kwargs['image_size'][0]
     destination_size_y = template_kwargs['image_size'][1]
 

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -461,7 +461,7 @@ def subpixel_template(sx, sy, dx, dy,
     d_template = bytescale(d_roi.clip(dtype=d_template_dtype))
     
     if verbose:
-         fig, axs = plt.subplots(1, 5, figsize=(20,10))
+         fig, axs = plt.subplots(1, 4, figsize=(20,10))
          axs[0].imshow(s_image, cmap='Greys')
          axs[1].imshow(d_template, cmap='Greys')
 
@@ -469,8 +469,7 @@ def subpixel_template(sx, sy, dx, dy,
 
     if verbose:
         axs[2].imshow(transformed_roi, cmap='Greys')
-        axs[3].imshow(d_template[5:-5,5:-5], cmap='Greys')
-        axs[4].imshow(corrmap)
+        axs[3].imshow(corrmap)
         plt.show()
     
     if (s_image is None) or (d_template is None):

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -527,8 +527,7 @@ def geom_match(base_cube,
                input_cube,
                bcenter_x,
                bcenter_y,
-               template_kwargs={"image_size":(59,59), "template_size":(31,31)},
-               phase_kwargs=None,
+               template_kwargs={"image_size":(59,59), "template_size":(31,31)}
                verbose=True):
     """
     Propagates a source measure into destination images and then perfroms subpixel registration.
@@ -559,9 +558,6 @@ def geom_match(base_cube,
 
     template_kwargs: dict
                      contains keywords necessary for autocnet.matcher.subpixel.subpixel_template
-
-    phase_kwargs:    dict
-                     contains kwargs for autocnet.matcher.subpixel.subpixel_phase
 
     verbose:    boolean
                 indicates level of print out desired. If True, two subplots are output; the first subplot contains

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -232,8 +232,8 @@ def subpixel_template(sx, sy, dx, dy,
                       image_size=(251, 251),
                       template_size=(51,51),
                       func=pattern_match,
-                      transform=None,
-                      verbose=False
+                      transform = None,
+                      verbose=False,
                       **kwargs):
     """
     Uses a pattern-matcher on subsets of two images determined from the passed-in keypoints and optional sizes to
@@ -267,16 +267,6 @@ def subpixel_template(sx, sy, dx, dy,
                     (xsize, ysize) of the template to iterate over the image in order
                     to identify the area(s) of highest correlation.
 
-    func : callable
-           A function to be used for the pattern matching. Can be `pattern match` or
-           `pattern_match_autoreg`
-
-    transform : obj
-                An skimage transformer object that is used to project the template into the image
-
-    verbose : bool
-              If True, include matplotlib figures that show the registration quality
-
     Returns
     -------
     x_shift : float
@@ -296,11 +286,15 @@ def subpixel_template(sx, sy, dx, dy,
     image_size = check_image_size(image_size)
     template_size = check_image_size(template_size)
 
-    ox = dx
-    oy = dy
+    if transform:
+        template_size_x = template_size[0] * transform.scale[0]
+        template_size_y = template_size[1] * transform.scale[1]
+    else:
+        template_size_x = template_size[0]
+        template_size_y = template_size[1]
 
     s_roi = roi.Roi(s_img, sx, sy, size_x=image_size[0], size_y=image_size[1])
-    d_roi = roi.Roi(d_img, dx, dy, size_x=template_size[0] * transform.scale[0], size_y=template_size[1] * transform.scale[1])
+    d_roi = roi.Roi(d_img, dx, dy, size_x=template_size_x, size_y=template_size_y)
 
     try:
         s_image_dtype = isis2np_types[pvl.load(s_img.file_name)["IsisCube"]["Core"]["Pixels"]["Type"]]
@@ -316,9 +310,9 @@ def subpixel_template(sx, sy, dx, dy,
     d_template = bytescale(d_roi.clip(dtype=d_template_dtype))
     
     if verbose:
-        fig, axs = plt.subplots(1, 5, figsize=(20,10))
-        axs[0].imshow(s_image, cmap='Greys')
-        axs[1].imshow(d_template, cmap='Greys')
+         fig, axs = plt.subplots(1, 5, figsize=(20,10))
+         axs[0].imshow(s_image, cmap='Greys')
+         axs[1].imshow(d_template, cmap='Greys')
 
     if transform:
         # Build the transformation chance
@@ -343,22 +337,24 @@ def subpixel_template(sx, sy, dx, dy,
 
         scaled_roi = tf.resize(transformed_roi, (int(template_shape_x/scale_x), int(template_shape_y/scale_x)))
         d_template = bytescale(scaled_roi)
-
-    if (s_image is None) or (d_template is None):
-        return None, None, None, None
-
-    shift_x, shift_y, metrics, corrmap = func(d_template[5:-5,5:-5], s_image, **kwargs)
+    else:
+        transformed_roi = d_template
 
     if verbose:
         axs[2].imshow(transformed_roi, cmap='Greys')
         axs[3].imshow(d_template[5:-5,5:-5], cmap='Greys')
         axs[4].imshow(corrmap)
         plt.show()
+    
+    if (s_image is None) or (d_template is None):
+        return None, None, None, None
+
+    shift_x, shift_y, metrics, corrmap = func(d_template[5:-5,5:-5], s_image, **kwargs)
 
     if transform:
         # Project the center into the affine space
         projected_center = itrans(d_roi.center)[0]
-        
+
         # Shifts need to be scaled back into full resolution, affine space
         shift_x *= scale_x
         shift_y *= scale_y
@@ -366,7 +362,7 @@ def subpixel_template(sx, sy, dx, dy,
         # Apply the shifts (computed using the warped image) to the affine space center
         new_projected_x = projected_center[0] - shift_x
         new_projected_y = projected_center[1] - shift_y
-        
+
         # Project the updated location back into image space
         new_unprojected_x, new_unprojected_y = trans([new_projected_x, new_projected_y])[0]
 
@@ -527,7 +523,8 @@ def geom_match(base_cube,
                input_cube,
                bcenter_x,
                bcenter_y,
-               template_kwargs={"image_size":(59,59), "template_size":(31,31)}
+               template_kwargs={"image_size":(59,59), "template_size":(31,31)},
+               phase_kwargs=None,
                verbose=True):
     """
     Propagates a source measure into destination images and then perfroms subpixel registration.
@@ -558,6 +555,9 @@ def geom_match(base_cube,
 
     template_kwargs: dict
                      contains keywords necessary for autocnet.matcher.subpixel.subpixel_template
+
+    phase_kwargs:    dict
+                     contains kwargs for autocnet.matcher.subpixel.subpixel_phase
 
     verbose:    boolean
                 indicates level of print out desired. If True, two subplots are output; the first subplot contains
@@ -655,40 +655,104 @@ def geom_match(base_cube,
     # Estimate the transformation
     affine = estimate_affine_transformation(base_corners, dst_corners)
 
-    # Apply the matcher
+    # Constant THEMIS scales.
+    # Multiple CTX by the scale to make it all big and such
     restemplate = subpixel_template(bcenter_x, bcenter_y, 
                                     center_x, center_y, 
                                     base_cube, input_cube, 
                                     transform=affine,
-                                    verbose=verbose
+                                    verbose=verbose,
                                     **template_kwargs)
 
-    x,y,metric,temp_corrmap = restemplate
-    
-    if x is None or y is None:
-        return None, None, None, None, None
-        
-    if verbose:
-        image_size = template_kwargs['image_size']
-        template_size = template_kwargs['template_size']
-        image_size = check_image_size(image_size)
-        template_size = check_image_size(template_size)
-        image_chip = roi.Roi(base_cube, bcenter_x, bcenter_y, size_x=image_size[0], size_y=image_size[1]).clip()
-        image_chip += 128  # Is this signed 8bit? huh?
-        temp_chip = roi.Roi(input_cube, x, y, size_x=template_size[0]*affine.scale[0], size_y=template_size[1]*affine.scale[1]).clip()
-        fig, axs = plt.subplots(1, 3, figsize=(15,15))
-        axs[0].set_title("Image Chip")
-        axs[0].imshow(image_chip, cmap="Greys_r")
-        chip_size = image_chip.shape
-        axs[0].plot(chip_size[1]/2, chip_size[0]/2, 'ro')
-        axs[1].set_title("Template Chip")
-        axs[1].imshow(bytescale(temp_chip), cmap="Greys_r")
-        temp_size = temp_chip.shape
-        axs[1].plot(temp_size[1]/2, temp_size[0]/2, 'ro')
-        pcm = axs[2].imshow(temp_corrmap**2, interpolation=None, cmap="coolwarm")
-        plt.show()
+    if phase_kwargs:
+        _,_,maxcorr, temp_corrmap = restemplate
+        sample_template, line_template = affine([restemplate[0], restemplate[1]])[0]
+        sample_template += start_x
+        line_template += start_y
+        dist_temp = np.linalg.norm([center_x-sample_template, center_y-line_template])
 
-    dist = np.linalg.norm([center_x-x, center_y-y])
+        resphase = subpixel_phase(size_x, size_y, restemplate[0], restemplate[1], base_arr, dst_arr, **phase_kwargs)
+        x,y,(perror, pdiff) = resphase
+        if x is None or y is None:
+            return None, None, None, None, None
+        sample, line = affine([x, y])[0]
+        sample += start_x
+        line += start_y
+        phase_dist = np.linalg.norm([sample_template-sample, line_template-line])
+
+        dist = (dist_temp, dist_phase)
+        metric = (maxcorr, perror, pdiff)
+    else:
+        x,y,maxcorr,temp_corrmap = restemplate
+        
+        if x is None or y is None:
+            return None, None, None, None, None
+        
+        if verbose:
+            image_size = template_kwargs['image_size']
+            template_size = template_kwargs['template_size']
+            image_size = check_image_size(image_size)
+            template_size = check_image_size(template_size)
+            image_chip = roi.Roi(base_cube, bcenter_x, bcenter_y, size_x=image_size[0], size_y=image_size[1]).clip()
+            temp_chip = roi.Roi(input_cube, x, y, size_x=template_size[0], size_y=template_size[1]).clip()
+            fig, axs = plt.subplots(1, 3, figsize=(15,15))
+            axs[0].set_title("Image Chip")
+            axs[0].imshow(bytescale(image_chip), cmap="Greys_r")
+            axs[1].set_title("Template Chip")
+            axs[1].imshow(bytescale(temp_chip), cmap="Greys_r")
+            print(temp_corrmap.shape)
+            pcm = axs[2].imshow(temp_corrmap**2, interpolation=None, cmap="coolwarm")
+            plt.show()
+
+            fig, axs = plt.subplots(1, 3, figsize=(15,15))
+            axs[0].set_title("Base")
+            axs[0].imshow(bytescale(base_arr), cmap="Greys_r")
+            axs[0].scatter(size_x, size_y, s=10, color='red')
+            axs[0].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
+            axs[0].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
+            #axs[0].set_xlim([0, base_arr.shape[0]])
+            #axs[0].set_ylim([0, base_arr.shape[1]])
+            axs[1].set_title("Unprojected Image\n w/ original point")
+            dst_arr = input_cube.read_array(pixels=dst_pixels, dtype=dst_type)
+            axs[1].imshow(bytescale(dst_arr), cmap="Greys_r")
+            #axs[1].scatter(warped_center_x, warped_center_y, s=10, color='blue')
+            nx, ny = affine([x,y])[0]
+            ox, oy = affine(warped_center)[0]
+            print(nx, ny)
+            axs[1].scatter(nx, ny, s=10, color='red')
+            axs[1].scatter(ox, oy, s=10, color='blue')
+            #axs[1].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
+            #axs[1].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
+            #axs[1].set_xlim([0, dst_arr[2:].shape[0]])
+            #axs[1].set_ylim([0, dst_arr[2:].shape[1]])
+            axs[2].set_title("Projected Image\n w/ registered point")
+            axs[2].imshow(bytescale(dst_arr[2:]), cmap="Greys_r")
+            axs[2].scatter(x, y, s=10, color='red')
+            axs[2].plot([0, size_x*2], [y, y], linewidth=0.75, color='red')
+            axs[2].plot([x, x], [0, size_y*2], linewidth=0.75, color='red')
+            #axs[2].set_xlim([0, dst_arr[2:].shape[0]])
+            #axs[2].set_ylim([0, dst_arr[2:].shape[1]])
+
+            plt.show()
+
+        dist = np.linalg.norm([center_x-x, center_y-y])
+        print('DIST', dist)
+        """if verbose:
+            fig, axs = plt.subplots(1, 2, figsize=(10,5))
+            # clip the image around the new line, sample
+            new_size_x = round(size_x*100/6) # 100/6 is a scaling between tehmis and CTX resolution
+            new_size_y = round(size_y*100/6)
+            new_dst_arr = roi.Roi(input_cube, sample, line, size_x=new_size_x, size_y=new_size_y).clip()
+            axs[0].imshow(new_dst_arr, cmap='Greys_r');
+            axs[0].scatter(new_size_x, new_size_y, s=10, color='red');
+            axs[0].set_title("Absolute\n Unprojected Image \nw/ registered point");
+
+            dst_arr_org = input_cube.read_array(pixels=dst_pixels, dtype=dst_type)
+            ssample, lline = affine([x, y])[0]
+            axs[1].imshow(dst_arr_org, cmap="Greys_r")
+            axs[1].scatter(ssample, lline, s=10, color='blue')
+            axs[1].set_title("Relative\n Unprojected Image\nw/registered point")
+            plt.show()"""
 
 
     return x, y, dist, metric, temp_corrmap
@@ -805,7 +869,6 @@ def subpixel_register_measure(measureid,
 def subpixel_register_point(pointid,
                             iterative_phase_kwargs={},
                             subpixel_template_kwargs={},
-                            size_x=100, size_y=100,
                             cost_func=lambda x,y: 1/x**2 * y,
                             threshold=0.005,
                             ncg=None,
@@ -874,12 +937,13 @@ def subpixel_register_point(pointid,
             destination_node = NetworkNode(node_id=destinationid, image_path=res.path)
             destination_node.parent = ncg
 
+            print('geom_match image:', res.path)
             try:
                 new_x, new_y, dist, metric,  _ = geom_match(source_node.geodata, destination_node.geodata,
                                                         source.sample, source.line,
                                                         template_kwargs=subpixel_template_kwargs,
                                                         phase_kwargs=iterative_phase_kwargs,
-                                                        size_x=size_y, size_y=size_x)
+                                                        size_x=100, size_y=100)
             except Exception as e:
                 print(f'geom_match failed on measure {measure.id} with exception -> {e}')
                 measure.ignore = True

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -232,7 +232,8 @@ def subpixel_template(sx, sy, dx, dy,
                       image_size=(251, 251),
                       template_size=(51,51),
                       func=pattern_match,
-                      transform = None,
+                      transform=None,
+                      verbose=False
                       **kwargs):
     """
     Uses a pattern-matcher on subsets of two images determined from the passed-in keypoints and optional sizes to
@@ -265,6 +266,16 @@ def subpixel_template(sx, sy, dx, dy,
     template_size : tuple
                     (xsize, ysize) of the template to iterate over the image in order
                     to identify the area(s) of highest correlation.
+
+    func : callable
+           A function to be used for the pattern matching. Can be `pattern match` or
+           `pattern_match_autoreg`
+
+    transform : obj
+                An skimage transformer object that is used to project the template into the image
+
+    verbose : bool
+              If True, include matplotlib figures that show the registration quality
 
     Returns
     -------
@@ -304,9 +315,10 @@ def subpixel_template(sx, sy, dx, dy,
     s_image = bytescale(s_roi.clip(dtype=s_image_dtype))
     d_template = bytescale(d_roi.clip(dtype=d_template_dtype))
     
-    fig, axs = plt.subplots(1, 5, figsize=(20,10))
-    axs[0].imshow(s_image, cmap='Greys')
-    axs[1].imshow(d_template, cmap='Greys')
+    if verbose:
+        fig, axs = plt.subplots(1, 5, figsize=(20,10))
+        axs[0].imshow(s_image, cmap='Greys')
+        axs[1].imshow(d_template, cmap='Greys')
 
     if transform:
         # Build the transformation chance
@@ -332,53 +344,38 @@ def subpixel_template(sx, sy, dx, dy,
         scaled_roi = tf.resize(transformed_roi, (int(template_shape_x/scale_x), int(template_shape_y/scale_x)))
         d_template = bytescale(scaled_roi)
 
-    #from skimage.exposure import match_histograms
-    #matched = match_histograms(bytescale(scaled_ctx), s_image)
-    #matched = bytescale(matched)
-    #matched = bytescale(scaled_ctx)
-
-    axs[2].imshow(transformed_roi, cmap='Greys')
-    axs[3].imshow(d_template[5:-5,5:-5], cmap='Greys')
-    
     if (s_image is None) or (d_template is None):
         return None, None, None, None
 
     shift_x, shift_y, metrics, corrmap = func(d_template[5:-5,5:-5], s_image, **kwargs)
 
+    if verbose:
+        axs[2].imshow(transformed_roi, cmap='Greys')
+        axs[3].imshow(d_template[5:-5,5:-5], cmap='Greys')
+        axs[4].imshow(corrmap)
+        plt.show()
+
     if transform:
         # Project the center into the affine space
         projected_center = itrans(d_roi.center)[0]
-        print('roi center', d_roi.center)
-        print(projected_center)
         
         # Shifts need to be scaled back into full resolution, affine space
         shift_x *= scale_x
         shift_y *= scale_y
-        print('shifts', shift_x, shift_y)
 
         # Apply the shifts (computed using the warped image) to the affine space center
         new_projected_x = projected_center[0] - shift_x
         new_projected_y = projected_center[1] - shift_y
         
-        print('new x, y in proj space', new_projected_x, new_projected_y)
-
         # Project the updated location back into image space
         new_unprojected_x, new_unprojected_y = trans([new_projected_x, new_projected_y])[0]
-        print('new xy in unproj (roi) space', new_unprojected_x, new_unprojected_y)
 
         dx = d_roi.x - (d_roi.center[0] - new_unprojected_x)
         dy = d_roi.y - (d_roi.center[1] - new_unprojected_y)
-        print('now in full images space', dx, dy)
     else:
         dx = d_roi.x - shift_x
         dy = d_roi.y - shift_y
 
-
-
-    axs[4].imshow(corrmap)
-    plt.show()
-
-    print('How far?',ox, oy, dx, dy, metrics)
     return dx, dy, metrics, corrmap
 
 def subpixel_ciratefi(sx, sy, dx, dy, s_img, d_img, search_size=251, template_size=51, **kwargs):
@@ -662,107 +659,40 @@ def geom_match(base_cube,
     # Estimate the transformation
     affine = estimate_affine_transformation(base_corners, dst_corners)
 
-    # Constant THEMIS scales.
-    # Multiple CTX by the scale to make it all big and such
+    # Apply the matcher
     restemplate = subpixel_template(bcenter_x, bcenter_y, 
                                     center_x, center_y, 
                                     base_cube, input_cube, 
                                     transform=affine,
+                                    verbose=verbose
                                     **template_kwargs)
 
-    if phase_kwargs:
-        _,_,maxcorr, temp_corrmap = restemplate
-        sample_template, line_template = affine([restemplate[0], restemplate[1]])[0]
-        sample_template += start_x
-        line_template += start_y
-        dist_temp = np.linalg.norm([center_x-sample_template, center_y-line_template])
-
-        resphase = subpixel_phase(size_x, size_y, restemplate[0], restemplate[1], base_arr, dst_arr, **phase_kwargs)
-        x,y,(perror, pdiff) = resphase
-        if x is None or y is None:
-            return None, None, None, None, None
-        sample, line = affine([x, y])[0]
-        sample += start_x
-        line += start_y
-        phase_dist = np.linalg.norm([sample_template-sample, line_template-line])
-
-        dist = (dist_temp, dist_phase)
-        metric = (maxcorr, perror, pdiff)
-    else:
-        x,y,metric,temp_corrmap = restemplate
+    x,y,metric,temp_corrmap = restemplate
+    
+    if x is None or y is None:
+        return None, None, None, None, None
         
-        if x is None or y is None:
-            return None, None, None, None, None
-        
-        if verbose:
-            image_size = template_kwargs['image_size']
-            template_size = template_kwargs['template_size']
-            image_size = check_image_size(image_size)
-            template_size = check_image_size(template_size)
-            image_chip = roi.Roi(base_cube, bcenter_x, bcenter_y, size_x=image_size[0], size_y=image_size[1]).clip()
-            image_chip += 128  # Is this signed 8bit? huh?
-            temp_chip = roi.Roi(input_cube, x, y, size_x=template_size[0]*affine.scale[0], size_y=template_size[1]*affine.scale[1]).clip()
-            fig, axs = plt.subplots(1, 3, figsize=(15,15))
-            axs[0].set_title("Image Chip")
-            axs[0].imshow(image_chip, cmap="Greys_r")
-            chip_size = image_chip.shape
-            axs[0].plot(chip_size[1]/2, chip_size[0]/2, 'ro')
-            axs[1].set_title("Template Chip")
-            axs[1].imshow(bytescale(temp_chip), cmap="Greys_r")
-            temp_size = temp_chip.shape
-            axs[1].plot(temp_size[1]/2, temp_size[0]/2, 'ro')
-            pcm = axs[2].imshow(temp_corrmap**2, interpolation=None, cmap="coolwarm")
-            plt.show()
+    if verbose:
+        image_size = template_kwargs['image_size']
+        template_size = template_kwargs['template_size']
+        image_size = check_image_size(image_size)
+        template_size = check_image_size(template_size)
+        image_chip = roi.Roi(base_cube, bcenter_x, bcenter_y, size_x=image_size[0], size_y=image_size[1]).clip()
+        image_chip += 128  # Is this signed 8bit? huh?
+        temp_chip = roi.Roi(input_cube, x, y, size_x=template_size[0]*affine.scale[0], size_y=template_size[1]*affine.scale[1]).clip()
+        fig, axs = plt.subplots(1, 3, figsize=(15,15))
+        axs[0].set_title("Image Chip")
+        axs[0].imshow(image_chip, cmap="Greys_r")
+        chip_size = image_chip.shape
+        axs[0].plot(chip_size[1]/2, chip_size[0]/2, 'ro')
+        axs[1].set_title("Template Chip")
+        axs[1].imshow(bytescale(temp_chip), cmap="Greys_r")
+        temp_size = temp_chip.shape
+        axs[1].plot(temp_size[1]/2, temp_size[0]/2, 'ro')
+        pcm = axs[2].imshow(temp_corrmap**2, interpolation=None, cmap="coolwarm")
+        plt.show()
 
-            """fig, axs = plt.subplots(1, 3, figsize=(15,15))
-            axs[0].set_title("Base")
-            axs[0].imshow(bytescale(base_arr), cmap="Greys_r")
-            axs[0].scatter(size_x, size_y, s=10, color='red')
-            axs[0].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
-            axs[0].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
-            #axs[0].set_xlim([0, base_arr.shape[0]])
-            #axs[0].set_ylim([0, base_arr.shape[1]])
-            axs[1].set_title("Unprojected Image\n w/ original point")
-            dst_arr = input_cube.read_array(pixels=dst_pixels, dtype=dst_type)
-            axs[1].imshow(bytescale(dst_arr), cmap="Greys_r")
-            #axs[1].scatter(warped_center_x, warped_center_y, s=10, color='blue')
-            nx, ny = affine([x,y])[0]
-            ox, oy = affine(warped_center)[0]
-            print(nx, ny)
-            axs[1].scatter(nx, ny, s=10, color='red')
-            axs[1].scatter(ox, oy, s=10, color='blue')
-            #axs[1].plot([0, size_x*2], [size_y, size_y], linewidth=0.75, color='red')
-            #axs[1].plot([size_x, size_x], [0, size_y*2], linewidth=0.75, color='red')
-            #axs[1].set_xlim([0, dst_arr[2:].shape[0]])
-            #axs[1].set_ylim([0, dst_arr[2:].shape[1]])
-            axs[2].set_title("Projected Image\n w/ registered point")
-            axs[2].imshow(bytescale(dst_arr[2:]), cmap="Greys_r")
-            axs[2].scatter(x, y, s=10, color='red')
-            axs[2].plot([0, size_x*2], [y, y], linewidth=0.75, color='red')
-            axs[2].plot([x, x], [0, size_y*2], linewidth=0.75, color='red')
-            #axs[2].set_xlim([0, dst_arr[2:].shape[0]])
-            #axs[2].set_ylim([0, dst_arr[2:].shape[1]])
-
-            plt.show()"""
-
-        dist = np.linalg.norm([center_x-x, center_y-y])
-        print('DIST', dist)
-        """if verbose:
-            fig, axs = plt.subplots(1, 2, figsize=(10,5))
-            # clip the image around the new line, sample
-            new_size_x = round(size_x*100/6) # 100/6 is a scaling between tehmis and CTX resolution
-            new_size_y = round(size_y*100/6)
-            new_dst_arr = roi.Roi(input_cube, sample, line, size_x=new_size_x, size_y=new_size_y).clip()
-            axs[0].imshow(new_dst_arr, cmap='Greys_r');
-            axs[0].scatter(new_size_x, new_size_y, s=10, color='red');
-            axs[0].set_title("Absolute\n Unprojected Image \nw/ registered point");
-
-            dst_arr_org = input_cube.read_array(pixels=dst_pixels, dtype=dst_type)
-            ssample, lline = affine([x, y])[0]
-            axs[1].imshow(dst_arr_org, cmap="Greys_r")
-            axs[1].scatter(ssample, lline, s=10, color='blue')
-            axs[1].set_title("Relative\n Unprojected Image\nw/registered point")
-            plt.show()"""
+    dist = np.linalg.norm([center_x-x, center_y-y])
 
 
     return x, y, dist, metric, temp_corrmap
@@ -948,7 +878,6 @@ def subpixel_register_point(pointid,
             destination_node = NetworkNode(node_id=destinationid, image_path=res.path)
             destination_node.parent = ncg
 
-            print('geom_match image:', res.path)
             try:
                 new_x, new_y, dist, metric,  _ = geom_match(source_node.geodata, destination_node.geodata,
                                                         source.sample, source.line,

--- a/autocnet/transformation/roi.py
+++ b/autocnet/transformation/roi.py
@@ -36,8 +36,8 @@ class Roi():
     bottom_y : int
                The bottom image coordinate in imge space
     """
-    def __init__(self, geodataset, x, y, size_x=200, size_y=200):
-        self.geodataset = geodataset
+    def __init__(self, data, x, y, size_x=200, size_y=200):
+        self.data = data
 
         self.x = x
         self.y = y
@@ -68,10 +68,10 @@ class Roi():
         """
         try:
             # Geodataset object
-            raster_size = self.geodataset.raster_size
-        except:
+            raster_size = self.data.raster_size
+        except: 
             # Numpy array in y,x form
-            raster_size = self.geodataset.shape[::-1]
+            raster_size = self.data.shape[::-1]
 
         # what is the extent that can actually be extracted?
         left_x = self._x - self.size_x
@@ -90,15 +90,20 @@ class Roi():
 
         return list(map(int, [left_x, right_x, top_y, bottom_y]))
 
+    @property
+    def center(self):
+        ie = self.image_extent
+        return (ie[1] - ie[0])/2, (ie[3]-ie[2])/2
+
     def clip(self, dtype=None):
         pixels = self.image_extent
-        if isinstance(self.geodataset, np.ndarray):
-            array = self.geodataset[pixels[2]:pixels[3]+1,
+        if isinstance(self.data, np.ndarray):
+            array = self.data[pixels[2]:pixels[3]+1,
                                          pixels[0]:pixels[1]+1]
         else:
             # Have to reformat to [xstart, ystart, xnumberpixels, ynumberpixels]
             pixels = [pixels[0], pixels[2], pixels[1]-pixels[0], pixels[3]-pixels[2]]
-            array = self.geodataset.read_array(pixels=pixels, dtype=dtype)
+            array = self.data.read_array(pixels=pixels, dtype=dtype)
 
         return array
 


### PR DESCRIPTION
This PR alters the subpixel registration to use an affine transform that is centered on the ROI (instead of the upper left corner). I have a notebook that demos how this is working that I would be happy to show via a private gist link. 

I will comment inline if that helps though I tried to comment in the code directly so that the why is longer lived.