### PR TITLE
Adds arbitrary weights to the edges for use in then finding islands

### DIFF
--- a/autocnet/graph/edge.py
+++ b/autocnet/graph/edge.py
@@ -1005,6 +1005,7 @@ class NetworkEdge(Edge):
     def measures(self):
         with self.parent.session_scope() as session:
             res = session.query(Measures).filter(sqlalchemy.or_(Measures.imageid == self.source['node_id'], Measures.imageid == self.destination['node_id'])).all()
+            session.expunge_all()
         return res
 
     def network_to_matches(self, ignore_point=False, ignore_measure=False, rejected_jigsaw=False):

--- a/autocnet/graph/edge.py
+++ b/autocnet/graph/edge.py
@@ -72,12 +72,14 @@ class Edge(dict, MutableMapping):
 
     @property
     def weights(self):
-        return getattr(self, '_weights', {})
+        if not hasattr(self, '_weights'):
+            self._weights = {}
+        return self._weights
 
     @weights.setter
     def weights(self, kv):
         key, value = kv
-        self._weights[key] = value
+        self.weights[key] = value
 
     @property
     def masks(self):
@@ -617,8 +619,8 @@ class Edge(dict, MutableMapping):
 
         overlapinfo = cg.two_poly_overlap(poly1, poly2)
 
-        self['weights'] = ('overlap_area', overlapinfo[1])
-        self['weights'] = ('overlap_percn', overlapinfo[0])
+        self.weights = ('overlap_area', overlapinfo[1])
+        self.weights = ('overlap_percn', overlapinfo[0])
 
     def coverage(self, clean_keys = []):
         """

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -950,9 +950,11 @@ class CandidateGraph(nx.Graph):
         : Object
           A networkX graph object
         """
-        edges = [(u, v) for u, v, edge in self.edges.data(
-            'data') if func(edge, *args, **kwargs)]
-        return self.create_edge_subgraph(edges)
+        edges_to_remove = [(u, v) for u, v, edge in self.edges.data(
+                            'data') if func(edge, *args, **kwargs)]
+        subgraph = nx.create_empty_copy(self)
+        subgraph.add_edges_from(edges_to_remove)
+        return subgraph
 
     def compute_cliques(self, node_id=None):  # pragma: no cover
         """

--- a/autocnet/graph/network.py
+++ b/autocnet/graph/network.py
@@ -750,15 +750,6 @@ class CandidateGraph(nx.Graph):
         """
         return nx.isolates(self)
 
-    def filter_by_weight(self, threshold):
-        def filter_edge(n1, n2):
-            if self[n1][n2]['weight'] > threshold:
-                return True
-            return False
-
-        vg = nx.subgraph_view(g, filter_edge=filter_edge)
-        return sorted(nx.connected_components(vg), key=len, reverse=True)
-
     def connected_subgraphs(self):
         """
         Finds and returns a list of each connected subgraph of nodes. Each subgraph is a set.

--- a/autocnet/graph/tests/test_edge.py
+++ b/autocnet/graph/tests/test_edge.py
@@ -52,6 +52,13 @@ class TestEdge(unittest.TestCase):
         self.assertEqual(e['weights']['overlap_area'], 400)
         self.assertAlmostEqual(e['weights']['overlap_percn'], 14.285714285)
 
+    def test_weight(self):
+        e = edge.Edge()
+        assert e.weight == 1
+        func = lambda x: x
+        e.set_weight(func, 2)
+        assert e.weight  == 2
+
     def test_coverage(self):
         adjacency = get_path('two_image_adjacency.json')
         basepath = get_path('Apollo15')

--- a/autocnet/graph/tests/test_edge.py
+++ b/autocnet/graph/tests/test_edge.py
@@ -29,7 +29,6 @@ class TestEdge(unittest.TestCase):
 
     def test_edge_overlap(self):
         e = edge.Edge()
-        e.weight = {}
         source = Mock(spec = node.Node)
         destination = Mock(spec = node.Node)
         e.destination = destination
@@ -49,15 +48,16 @@ class TestEdge(unittest.TestCase):
         destination.geodata.footprint = poly2
 
         e.overlap()
-        self.assertEqual(e['weights']['overlap_area'], 400)
-        self.assertAlmostEqual(e['weights']['overlap_percn'], 14.285714285)
+        self.assertEqual(e.weights['overlap_area'], 400)
+        self.assertAlmostEqual(e.weights['overlap_percn'], 14.285714285)
 
     def test_weight(self):
         e = edge.Edge()
-        assert e.weight == 1
-        func = lambda x: x
-        e.set_weight(func, 2)
-        assert e.weight  == 2
+        assert e.weights == {}
+        e.weights = ('foo', 1)
+        assert e.weights['foo']  == 1
+        e.weights = ('foo', 2)
+        assert e.weights['foo']  == 2
 
     def test_coverage(self):
         adjacency = get_path('two_image_adjacency.json')

--- a/autocnet/graph/tests/test_network.py
+++ b/autocnet/graph/tests/test_network.py
@@ -213,12 +213,19 @@ def test_get_matches(candidategraph):
 def test_island_nodes(disconnected_graph):
     assert len(list(disconnected_graph.island_nodes())) == 1
 
+def test_setting_weights(candidategraph):
+    for s, d, e in candidategraph.edges(data='data'):
+        def func(x, y=1):
+            return x**y
+        e.set_weight(func, 2, y=2)
+
+    for s, d, e in candidategraph.edges(data='data'):
+        assert e.weight == 4
 
 def test_triangular_cycles(graph):
     cycles = graph.compute_triangular_cycles()
     # Node order is variable, length is not
     assert len(cycles) == 1
-
 
 def test_connected_subgraphs(graph, disconnected_graph):
     # Calls all return generators, cast to list for positional comparison

--- a/autocnet/graph/tests/test_network.py
+++ b/autocnet/graph/tests/test_network.py
@@ -213,15 +213,6 @@ def test_get_matches(candidategraph):
 def test_island_nodes(disconnected_graph):
     assert len(list(disconnected_graph.island_nodes())) == 1
 
-def test_setting_weights(candidategraph):
-    for s, d, e in candidategraph.edges(data='data'):
-        def func(x, y=1):
-            return x**y
-        e.set_weight(func, 2, y=2)
-
-    for s, d, e in candidategraph.edges(data='data'):
-        assert e.weight == 4
-
 def test_triangular_cycles(graph):
     cycles = graph.compute_triangular_cycles()
     # Node order is variable, length is not

--- a/autocnet/io/db/model.py
+++ b/autocnet/io/db/model.py
@@ -128,6 +128,7 @@ class Edges(BaseMixin, Base):
     fundamental = Column(ArrayType())
     ignore = Column(Boolean, default=False)
     masks = Column(Json())
+    weights = Column(Json())
 
 class Costs(BaseMixin, Base):
     __tablename__ = 'costs'

--- a/autocnet/utils/serializers.py
+++ b/autocnet/utils/serializers.py
@@ -21,7 +21,6 @@ class JsonEncoder(json.JSONEncoder):
         if isinstance(obj,  shapely.geometry.base.BaseGeometry):
             return obj.wkt
         if callable(obj):
-            
             return encodebytes(dill.dumps(obj)).decode()
         return json.JSONEncoder.default(self, obj)
 

--- a/bin/acn_submit
+++ b/bin/acn_submit
@@ -58,14 +58,18 @@ def main(msg):
         obj = _instantiate_obj(msg, ncg)
     elif msg['along'] in ['points', 'measures', 'overlaps']:
         obj = _instantiate_row(msg, ncg)
+
     # Grab the function and apply. This assumes that the func is going to
     # have a True/False return value. Basically, all processing needs to
     # occur inside of the func, nothing belongs in here.
     #
     # All args/kwargs are passed through the RedisQueue, and then right on to the func.
-    if hasattr(obj, msg['func']): 
+    func = msg['func']
+    if callable(func):  # The function is a de-serialzied function
+        msg['args'] = (obj, *msg['args'])
+    elif hasattr(obj, msg['func']):  # The function is a method on the object
         func = getattr(obj, msg['func'])
-    else:
+    else:  # The func is a function from a library to be imported
         func = import_func(msg['func'])
         # Get the object begin processed prepended into the args.
         msg['args'] = (obj, *msg['args'])

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -50,6 +50,7 @@ requirements:
       - plio>=1.1.0
       - plurmy
       - psycopg2
+      - pvl<1.0.0
       - pyproj
       - pysis
       - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pysis
+  - pvl < 1.0
   - scikit-image
   - scikit-learn
   - scipy<=1.2.1


### PR DESCRIPTION
This PR gets edges setup to be persistent into the DB. Once persistent in the DB, we can use the weights to do all kinds of different masking operations.

Examples:

## Applying a weight using a function
```
# Set the edge weights using some function:
def weight_func(edge):
    edge.weights = ('byid', edge.source['node_id'] % 2)
    return True

ncg.apply(weight_func, on='edge')
```

Here the arbitrary `weight_func` is being applied to every edge. Since we are applying to an edge, the first arg is the edge itself. Here we access the weights attribute (that is a dict under the hood) and use the setter to add or update the `byid` key with a value derived from the `node id` of the source node. Since the function in here runs on the edge, it can access anything that the edge can access and since the edge has a `parent` attribute that is the graph, that is basically everything.

So, we can write a function like so to apply a weight based on the number of active (not ignored) measures:
```
# Set the edge weights using some function:
def weight_func(edge):
    number_activemeasures = sum([True for i in edge.measures if i.ignore == False])
    edge.weights = ('number_activemeasure', number_activemeasures)
    return True

ncg.apply(weight_func, on='edge')
``` 

Once the edge has been updated, it is possible to filter edges based on another arbitrary function:
```
# Arbitrary function that masks based on a given threshold.
def func(edge, key, threshold=2):    
    return edge.weights[key] > threshold

subgraph = ncg.filter_edges(func, key='number_activemeasure', threshold=400)
```
Here, we return True on an edge if the weight for a given key is greater than a threshold. This example is very arbitrary in that it is requesting to retain all nodes where the edge weight is greater than 400. The arbitrary function needs to take in the object, any arguments, and then any kwargs. It needs to return a boolean.

Once we have the subgraph(s), it is possible to look at the number of independent connected components to find islands or completely disconnect subgraphs. For example: 

```
print(subgraph.connected_subgraphs())
```

This last capability is still a WIP in this PR.