### PR TITLE
Removed dev label from usgscsm

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,5 +36,5 @@ dependencies:
   - sqlalchemy
   - sqlalchemy-utils
   - redis-py
-  - usgs-astrogeology/label/dev::usgscsm
+  - usgscsm
   - vlfeat


### PR DESCRIPTION
The dev builds of travis are having an issue with their compilation flags causing symbols errors. Switching to the conda-forge version fixes this. Fixes #499 