### PR TITLE
Fixed missing line in nb

### DIFF
--- a/docs/users/workshops/FY21_workshop/python_software_tutorial.ipynb
+++ b/docs/users/workshops/FY21_workshop/python_software_tutorial.ipynb
@@ -128,6 +128,7 @@
    "metadata": {
     "collapsed": true
    },
+   "source": [
     "#### Exercise: Use the ? symbol to find more information about the following objects: print, type, np.dot, np.dtype)."
    ]
   },


### PR DESCRIPTION
Somehow this line in the notebook got deleted and was causing parsing error when it was opened.