### PR TITLE
ticked version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def setup_package():
 
     setup(
         name = "autocnet",
-        version = '0.2.7',
+        version = '0.4.0',
         author = "Jay Laura",
         author_email = "jlaura@usgs.gov",
         description = ("I/O API to support planetary data formats."),


### PR DESCRIPTION
Not sure if we really need to change much else? I recall version 0.4.0 was the target. 

Does this version have to be manually pushed to https://anaconda.org/usgs-astrogeology/autocnet after this gets merged?  