### PR TITLE
Removes unneeded postgis template instruction from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ We suggest using Anaconda Python to install Autocnet within a virtual environmen
 
 1. Install Docker
 2. Get the Postgresql with Postgis container and run it `docker run --name testdb -e POSTGRES_PASSOWRD='NotTheDefault' -e POSTGRES_USER='postgres' -p 5432:5432 -d mdillon/postgis`
-3. create database template_postgis: `docker exec testdb psql -c 'create database template_postgis;' -U postgres`
-4. Run the test suite: `pytest autocnet`
+3. Run the test suite: `pytest autocnet`
 
 ## Simple Network Examples:
 


### PR DESCRIPTION
Fixes #563.

Minor removal of a line in the test setup instructions that is not needed.