### PR TITLE
Convert from pysis to kalasiris and rewrite of spatial/isis.py

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -74,7 +74,7 @@ jobs:
           environment-file: environment.yml
           use-only-tar-bz2: true
           python-version: ${{ matrix.python-version }}
-     - name: config ISIS vars
+      - name: config ISIS vars
         run: |
           conda env config vars set ISISROOT=${{ env.isis-root }}
           conda env config vars set ISISDATA=$GITHUB_WORKSPACE/${{ env.isis-data }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -46,8 +46,8 @@ jobs:
         run: |
           mkdir $GITHUB_WORKSPACE/test-resources/
           mkdir $GITHUB_WORKSPACE/${{ env.isis-data }}
-       - name: Download IMG
-          run: curl "https://hirise-pds.lpl.arizona.edu/PDS/EDR/PSP/ORB_010500_010599/PSP_010502_2090/PSP_010502_2090_RED5_0.IMG" -o $GITHUB_WORKSPACE/test-resources/PSP_010502_2090_RED5_0.img
+      - name: Download IMG
+        run: curl "https://hirise-pds.lpl.arizona.edu/PDS/EDR/PSP/ORB_010500_010599/PSP_010502_2090/PSP_010502_2090_RED5_0.IMG" -o $GITHUB_WORKSPACE/test-resources/PSP_010502_2090_RED5_0.img
       - name: Exit isis env
         run: conda deactivate
       - name: Checkout Code

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - dev
 
+env:
+  isis-root: /usr/share/miniconda/envs/isis/
+  isis-data: test-resources/ISISDATA/
+
 jobs:
   Build-and-Test:
     runs-on: ${{ matrix.os }}
@@ -29,6 +33,23 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
+      - name: ISIS Conda Env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.6
+          activate-environment: isis
+          channels: usgs-astrogeology, conda-forge
+      - name: Install ISIS
+        run: |
+          conda install -q -y -c usgs-astrogeology isis
+      - name: Setup test-resources/
+        run: |
+          mkdir $GITHUB_WORKSPACE/test-resources/
+          mkdir $GITHUB_WORKSPACE/${{ env.isis-data }}
+       - name: Download IMG
+          run: curl "https://hirise-pds.lpl.arizona.edu/PDS/EDR/PSP/ORB_010500_010599/PSP_010502_2090/PSP_010502_2090_RED5_0.IMG" -o $GITHUB_WORKSPACE/test-resources/PSP_010502_2090_RED5_0.img
+      - name: Exit isis env
+        run: conda deactivate
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Cache conda
@@ -53,6 +74,10 @@ jobs:
           environment-file: environment.yml
           use-only-tar-bz2: true
           python-version: ${{ matrix.python-version }}
+     - name: config ISIS vars
+        run: |
+          conda env config vars set ISISROOT=${{ env.isis-root }}
+          conda env config vars set ISISDATA=$GITHUB_WORKSPACE/${{ env.isis-data }}
       - name: Check build environment
         run: |
           conda list

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,6 +11,7 @@ on:
 env:
   isis-root: /usr/share/miniconda/envs/isis/
   isis-data: test-resources/ISISDATA/
+  hirise-pds-url: https://hirise-pds.lpl.arizona.edu/PDS/EDR/PSP/ORB_010500_010599/PSP_010502_2090
 
 jobs:
   Build-and-Test:
@@ -47,7 +48,9 @@ jobs:
           mkdir $GITHUB_WORKSPACE/test-resources/
           mkdir $GITHUB_WORKSPACE/${{ env.isis-data }}
       - name: Download IMG
-        run: curl "https://hirise-pds.lpl.arizona.edu/PDS/EDR/PSP/ORB_010500_010599/PSP_010502_2090/PSP_010502_2090_RED5_0.IMG" -o $GITHUB_WORKSPACE/test-resources/PSP_010502_2090_RED5_0.img
+        run: |
+          curl "${{ env.hirise-pds-url }}/PSP_010502_2090_RED5_0.IMG" -o $GITHUB_WORKSPACE/test-resources/PSP_010502_2090_RED5_0.img
+          curl "${{ env.hirise-pds-url }}/PSP_010502_2090_RED5_1.IMG" -o $GITHUB_WORKSPACE/test-resources/PSP_010502_2090_RED5_1.img
       - name: Exit isis env
         run: conda deactivate
       - name: Checkout Code

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,4 +15,5 @@ Development Team
 Contributors
 ------------
 
-None yet. Why not be the first?
+`Ross Beyer <https://github.com/rbeyer>`_
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+.PHONY: clean clean-test clean-pyc clean-build docs help
+.DEFAULT_GOAL := help
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+define DOWNLOAD_PYSCRIPT
+import urllib.request, sys
+
+urllib.request.urlretrieve(sys.argv[1],sys.argv[2])
+endef
+export DOWNLOAD_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+DOWNLOAD := python -c "$$DOWNLOAD_PYSCRIPT"
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+	rm -fr .pytest_cache
+	rm -fr test-resources
+
+lint: ## check style with flake8
+	flake8 --max-complexity 10 --ignore E203,E501,W503 autocnet tests
+
+test: test-resources ## run tests quickly with the default Python
+	pytest autocnet
+
+test-resources: ## Download what we need for testing
+	mkdir test-resources
+	$(DOWNLOAD) https://hirise-pds.lpl.arizona.edu/PDS/EDR/PSP/ORB_010500_010599/PSP_010502_2090/PSP_010502_2090_RED5_0.IMG test-resources/PSP_010502_2090_RED5_0.img
+	$(DOWNLOAD) https://hirise-pds.lpl.arizona.edu/PDS/EDR/PSP/ORB_010500_010599/PSP_010502_2090/PSP_010502_2090_RED5_1.IMG test-resources/PSP_010502_2090_RED5_1.img
+
+
+test-all: ## run tests on every Python version with tox
+	tox
+
+coverage: test  ## check code coverage quickly with the default Python
+	coverage report -m
+	coverage html
+	$(BROWSER) htmlcov/index.html
+
+docs: ## generate Sphinx HTML documentation, including API docs
+	rm -f docs/autocnet.rst
+	rm -f docs/modules.rst
+	sphinx-apidoc -o docs/ autocnet
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs html
+	$(BROWSER) docs/_build/html/index.html
+
+servedocs: docs ## compile the docs watching for changes
+	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
+
+release: dist ## package and upload a release
+	twine upload dist/*
+
+dist: clean ## builds source and wheel package
+	python setup.py sdist
+	python setup.py bdist_wheel
+	ls -l dist
+
+install: clean ## install the package to the active Python's site-packages
+	python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ clean-test: ## remove test and coverage artifacts
 lint: ## check style with flake8
 	flake8 --max-complexity 10 --ignore E203,E501,W503 autocnet tests
 
-test: test-resources ## run tests quickly with the default Python
+test: ## run tests quickly with the default Python
 	pytest autocnet
 
 test-resources: ## Download what we need for testing

--- a/README.md
+++ b/README.md
@@ -17,10 +17,34 @@ Is available at: https://usgs-astrogeology.github.io/autocnet/
 We suggest using Anaconda Python to install Autocnet within a virtual environment.  These steps will walk you through the process.
 
 1. [Download](https://www.continuum.io/downloads) and install the Python 3.x Miniconda installer.  Respond ``Yes`` when prompted to add conda to your BASH profile.
-2. Install `mamba`. [`mamba`](https://github.com/mamba-org/mamba) is a fast cross platform package manager that has, in our experience, improved environment solving. The AutoCNet environment is complex and `mamba` is necessary to get a solve. To install `conda install -c conda-forge mamba`.
-3. Install the autocnet environment using the supplied environment.yml file: `mamba env create -n autocnet -f environment.yml` 
-4. Activate your environment: `conda activate autocnet`
-5. If you are doing to develop autocnet or would like to use the bleeding edge version: `python setup.py develop`. Otherwise, `conda install -c usgs-astrogeology autocnet`
+2. Install ISIS.   Follow the 
+   [instructions to install ISIS](https://github.com/USGS-Astrogeology/ISIS3#installation) in its own conda 
+   environment. With that ISIS environment activated, determine the values for the ISIS environment 
+   variables, with a command like this (may vary by your shell):
+
+   `printenv | grep ISIS`
+
+   Copy down the values of ISISROOT and ISISDATA.  Exit the ISIS environment. 
+   
+3. Install `mamba`. [`mamba`](https://github.com/mamba-org/mamba) is a fast cross platform package manager that has, in our experience, improved environment solving. The AutoCNet environment is complex and `mamba` is necessary to get a solve. To install `conda install -c conda-forge mamba`.
+4. Install the autocnet environment using the supplied environment.yml file: `mamba env create -n autocnet -f environment.yml` 
+5. Activate your environment: `conda activate autocnet`
+6. Ensure ISISROOT and ISISDATA are set in the *autocnet* environment.  One way is to
+   ```
+   conda env config vars set ISISROOT=value-you-wrote-down-from-step-2
+   conda env config vars set ISISDATA=value-you-wrote-down-from-step-2
+   conda deactivate
+   conda activate autocnet
+   ```
+   If you use Jupyter notebooks, you may need to do the following in a cell before importing 
+   *autocnet* modules:
+   ```
+   import os
+   os.environ["ISISROOT"] = "path-you-wrote-down-in-step-2"
+   os.environ["ISISDATA"] = "path-you-wrote-down-in-step-2"
+   ```
+   
+7. If you are going to develop autocnet or would like to use the bleeding edge version: `python setup.py develop`. Otherwise, `conda install -c usgs-astrogeology autocnet`
 
 ## How to run the test suite locally
 

--- a/autocnet/cg/change_detection.py
+++ b/autocnet/cg/change_detection.py
@@ -26,7 +26,7 @@ import richdem as rd
 import pandas as pd
 import geopandas as gpd
 
-import pysis
+from kalasiris import specialpixels
 
 from autocnet.utils.utils import bytescale
 from autocnet.matcher.cpu_extractor import extract_features
@@ -57,7 +57,7 @@ def image_diff(arr1, arr2):
     arr1[arr1 == 0] = np.nan
     arr2[arr2 == 0] = np.nan
 
-    isis_null = pysis.specialpixels.SPECIAL_PIXELS['Real']['Null']
+    isis_null = specialpixels.Real.Null
     arr1[arr1 == isis_null] = np.nan
     arr2[arr2 == isis_null] = np.nan
 
@@ -92,7 +92,7 @@ def image_ratio(arr1, arr2):
     arr1[arr1 == 0] = np.nan
     arr2[arr2 == 0] = np.nan
 
-    isis_null = pysis.specialpixels.SPECIAL_PIXELS['Real']['Null']
+    isis_null = specialpixels.Real.Null
     arr1[arr1 == isis_null] = np.nan
     arr2[arr2 == isis_null] = np.nan
 

--- a/autocnet/cg/tests/test_change_detection.py
+++ b/autocnet/cg/tests/test_change_detection.py
@@ -1,0 +1,35 @@
+"""This module has tests for the change_detection functions."""
+
+# This is free and unencumbered software released into the public domain.
+#
+# The authors of autocnet do not claim copyright on the contents of this file.
+# For more details about the LICENSE terms and the AUTHORS, you will
+# find files of those names at the top level of this repository.
+#
+# SPDX-License-Identifier: CC0-1.0
+
+import unittest
+import numpy as np
+import numpy.testing as npt
+from autocnet.cg import change_detection as cd
+
+
+class TestISIS(unittest.TestCase):
+
+    def test_image_diff(self):
+        arr1 = np.array([1.0, 2.0, -3.4028227e+38])
+        arr2 = np.array([1.0, 3.0, 0])
+
+        npt.assert_array_equal(
+            np.array([0, -1.0, 0]),
+            cd.image_diff(arr1, arr2)
+        )
+
+    def test_image_ratio(self):
+        arr1 = np.array([1.0, 4.0, -3.4028227e+38])
+        arr2 = np.array([1.0, 2.0, 0])
+
+        npt.assert_array_equal(
+            np.array([1.0, 2.0, 0]),
+            cd.image_ratio(arr1, arr2)
+        )

--- a/autocnet/matcher/cross_instrument_matcher.py
+++ b/autocnet/matcher/cross_instrument_matcher.py
@@ -82,12 +82,12 @@ def generate_ground_points(Session, ground_mosaic, nspts_func=lambda x: int(roun
         if linessamples is None:
             print('unable to find point in ground image')
             continue
-        line = linessamples[0].get('Line')
-        sample = linessamples[0].get('Sample')
+        line = linessamples.get('Line')
+        sample = linessamples.get('Sample')
 
         oldpoint = isis.point_info(ground_mosaic.file_name, sample, line, 'image')
-        op = Point(oldpoint[0].get('PositiveEast360Longitude'),
-                   oldpoint[0].get('PlanetocentricLatitude'))
+        op = Point(oldpoint.get('PositiveEast360Longitude'),
+                   oldpoint.get('PlanetocentricLatitude'))
 
 
         image = roi.Roi(ground_mosaic, sample, line, size_x=size[0], size_y=size[1])
@@ -102,8 +102,8 @@ def generate_ground_points(Session, ground_mosaic, nspts_func=lambda x: int(roun
         newline = top_y + interesting.y
 
         newpoint = isis.point_info(ground_mosaic.file_name, newsample, newline, 'image')
-        p = Point(newpoint[0].get('PositiveEast360Longitude'),
-                  newpoint[0].get('PlanetocentricLatitude'))
+        p = Point(newpoint.get('PositiveEast360Longitude'),
+                  newpoint.get('PlanetocentricLatitude'))
 
         if not (xy_in_polygon(p.x, p.y, fp_poly)):
                 print('Interesting point not in mosaic area, ignore')

--- a/autocnet/matcher/ground.py
+++ b/autocnet/matcher/ground.py
@@ -163,7 +163,7 @@ def propagate_ground_point(point,
             sample, line = image_coord.samp, image_coord.line
         if cam_type == "isis":
             try:
-                line, sample = isis.ground_to_image(image["path"], lon_oc, lat_oc)
+                sample, line = isis.ground_to_image(image["path"], lon_oc, lat_oc)
             except ProcessError as e:
                 if 'Requested position does not project in camera model' in e.stderr:
                     print(f'interesting point ({lon_oc},{lat_oc}) does not project to image {images["image_path"]}')
@@ -219,8 +219,8 @@ def find_most_interesting_ground(apriori_lon_lat,
 
     # Convert the apriori lon, lat into line,sample in the image
     linessamples = isis.point_info(ground_mosaic.file_name, p.x, p.y, 'ground')
-    line = linessamples[0].get('Line')
-    sample = linessamples[0].get('Sample')
+    line = linessamples.get('Line')
+    sample = linessamples.get('Sample')
 
     # Get the most interesting feature in the area
     image = roi.Roi(ground_mosaic, sample, line, size_x=size, size_y=size)
@@ -238,8 +238,8 @@ def find_most_interesting_ground(apriori_lon_lat,
 
     # @LAK - this needs eyeballs to confirm correct oc/og
     newpoint = isis.point_info(ground_mosaic.file_name, newsample, newline, 'image')
-    p = Point(newpoint[0].get('PositiveEast360Longitude'),
-              newpoint[0].get('PlanetocentricLatitude'))
+    p = Point(newpoint.get('PositiveEast360Longitude'),
+              newpoint.get('PlanetocentricLatitude'))
 
     with ncg.session_scope() as session:
         # Check to see if the point already exists

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -4,6 +4,8 @@ import time
 import numpy as np
 import warnings
 
+from subprocess import CalledProcessError
+
 import numbers
 
 import sys
@@ -18,7 +20,6 @@ from scipy import fftpack
 from matplotlib import pyplot as plt
 
 from plio.io.io_gdal import GeoDataset
-from pysis.exceptions import ProcessError
 
 import pvl
 
@@ -890,7 +891,7 @@ def geom_match_simple(base_cube,
         try:
             lat, lon = spatial.isis.image_to_ground(base_cube.file_name, x, y)
             dst_corners.append(spatial.isis.ground_to_image(input_cube.file_name, lon, lat)[::-1])
-        except ProcessError as e:
+        except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {input_cube.base_name}')
                 return None, None, None, None, None
@@ -1086,7 +1087,7 @@ def geom_match_classic(base_cube,
         try:
             lat, lon = spatial.isis.image_to_ground(base_cube.file_name, x, y)
             dst_corners.append(spatial.isis.ground_to_image(input_cube.file_name, lon, lat)[::-1])
-        except ProcessError as e:
+        except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {input_cube.base_name}')
                 return None, None, None, None, None
@@ -1270,7 +1271,7 @@ def geom_match(destination_cube,
     try:
         mlat, mlon = spatial.isis.image_to_ground(destination_cube.file_name, bcenter_x, bcenter_y)
         center_y, center_x = spatial.isis.ground_to_image(source_cube.file_name, mlon, mlat)
-    except ProcessError as e:
+    except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest center located at ({mlon}, {mlat}) does not project to image {source_cube.base_name}')
                 print('This should only appear when propagating ground points')
@@ -1283,7 +1284,7 @@ def geom_match(destination_cube,
         try:
             lat, lon = spatial.isis.image_to_ground(destination_cube.file_name, x, y)
             source_corners.append(spatial.isis.ground_to_image(source_cube.file_name, lon, lat)[::-1])
-        except ProcessError as e:
+        except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {source_cube.base_name}')
                 return None, None, None, None, None

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -890,8 +890,9 @@ def geom_match_simple(base_cube,
     for x,y in base_corners:
         try:
             lon, lat = spatial.isis.image_to_ground(base_cube.file_name, x, y)
-            sample, line = spatial.isis.ground_to_image(input_cube.file_name, lon, lat)
-            dst_corners.append((line, sample))
+            dst_corners.append(
+                spatial.isis.ground_to_image(input_cube.file_name, lon, lat)
+            )
         except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {input_cube.base_name}')
@@ -1087,8 +1088,9 @@ def geom_match_classic(base_cube,
     for x,y in base_corners:
         try:
             lon, lat = spatial.isis.image_to_ground(base_cube.file_name, x, y)
-            sample, line = spatial.isis.ground_to_image(input_cube.file_name, lon, lat)
-            dst_corners.append((line, sample))
+            dst_corners.append(
+                spatial.isis.ground_to_image(input_cube.file_name, lon, lat)
+            )
         except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {input_cube.base_name}')
@@ -1285,8 +1287,9 @@ def geom_match(destination_cube,
     for x,y in destination_corners:
         try:
             lon, lat = spatial.isis.image_to_ground(destination_cube.file_name, x, y)
-            sample, line = spatial.isis.ground_to_image(source_cube.file_name, lon, lat)
-            source_corners.append((line, sample))
+            source_corners.append(
+                spatial.isis.ground_to_image(source_cube.file_name, lon, lat)
+            )
         except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {source_cube.base_name}')

--- a/autocnet/matcher/subpixel.py
+++ b/autocnet/matcher/subpixel.py
@@ -889,8 +889,9 @@ def geom_match_simple(base_cube,
     dst_corners = []
     for x,y in base_corners:
         try:
-            lat, lon = spatial.isis.image_to_ground(base_cube.file_name, x, y)
-            dst_corners.append(spatial.isis.ground_to_image(input_cube.file_name, lon, lat)[::-1])
+            lon, lat = spatial.isis.image_to_ground(base_cube.file_name, x, y)
+            sample, line = spatial.isis.ground_to_image(input_cube.file_name, lon, lat)
+            dst_corners.append((line, sample))
         except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {input_cube.base_name}')
@@ -1074,8 +1075,8 @@ def geom_match_classic(base_cube,
         raise Exception(f"Window: {base_starty} < 0, center: {bcenter_x},{bcenter_y}")
 
     # specifically not putting this in a try/except, this should never fail
-    mlat, mlon = spatial.isis.image_to_ground(base_cube.file_name, bcenter_x, bcenter_y)
-    center_x, center_y = spatial.isis.ground_to_image(input_cube.file_name, mlon, mlat)[::-1]
+    mlon, mlat = spatial.isis.image_to_ground(base_cube.file_name, bcenter_x, bcenter_y)
+    center_x, center_y = spatial.isis.ground_to_image(input_cube.file_name, mlon, mlat)
 
     base_corners = [(base_startx,base_starty),
                     (base_startx,base_stopy),
@@ -1085,8 +1086,9 @@ def geom_match_classic(base_cube,
     dst_corners = []
     for x,y in base_corners:
         try:
-            lat, lon = spatial.isis.image_to_ground(base_cube.file_name, x, y)
-            dst_corners.append(spatial.isis.ground_to_image(input_cube.file_name, lon, lat)[::-1])
+            lon, lat = spatial.isis.image_to_ground(base_cube.file_name, x, y)
+            sample, line = spatial.isis.ground_to_image(input_cube.file_name, lon, lat)
+            dst_corners.append((line, sample))
         except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {input_cube.base_name}')
@@ -1269,8 +1271,8 @@ def geom_match(destination_cube,
     # 07/28 - putting it in a try/except because of how we ground points
     # Transform from the destination center to the source_cube center
     try:
-        mlat, mlon = spatial.isis.image_to_ground(destination_cube.file_name, bcenter_x, bcenter_y)
-        center_y, center_x = spatial.isis.ground_to_image(source_cube.file_name, mlon, mlat)
+        mlon, mlat = spatial.isis.image_to_ground(destination_cube.file_name, bcenter_x, bcenter_y)
+        center_x, center_y = spatial.isis.ground_to_image(source_cube.file_name, mlon, mlat)
     except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest center located at ({mlon}, {mlat}) does not project to image {source_cube.base_name}')
@@ -1282,8 +1284,9 @@ def geom_match(destination_cube,
     source_corners = []
     for x,y in destination_corners:
         try:
-            lat, lon = spatial.isis.image_to_ground(destination_cube.file_name, x, y)
-            source_corners.append(spatial.isis.ground_to_image(source_cube.file_name, lon, lat)[::-1])
+            lon, lat = spatial.isis.image_to_ground(destination_cube.file_name, x, y)
+            sample, line = spatial.isis.ground_to_image(source_cube.file_name, lon, lat)
+            source_corners.append((line, sample))
         except CalledProcessError as e:
             if 'Requested position does not project in camera model' in e.stderr:
                 print(f'Skip geom_match; Region of interest corner located at ({lon}, {lat}) does not project to image {source_cube.base_name}')
@@ -1680,8 +1683,8 @@ def register_to_base(pointid,
             print('unable to find point in ground image')
             # Need to set the point to False
             return
-        bline = bpoint[0].get('Line')
-        bsample = bpoint[0].get('Sample')
+        bline = bpoint.get('Line')
+        bsample = bpoint.get('Sample')
 
         # Setup a cache so that we can get the file handles one time instead of 
         # once per measure in the measures list.

--- a/autocnet/spatial/isis.py
+++ b/autocnet/spatial/isis.py
@@ -1,191 +1,260 @@
-import pvl
-from warnings import warn
+"""This module contains wrappers around the ISIS campt and mappt that are
+specific to understanding the relationship between pixels and projected
+coordinates."""
+
+# This is free and unencumbered software released into the public domain.
+#
+# The authors of autocnet do not claim copyright on the contents of this file.
+# For more details about the LICENSE terms and the AUTHORS, you will
+# find files of those names at the top level of this repository.
+#
+# SPDX-License-Identifier: CC0-1.0
+
+import os
+from collections import abc
 from numbers import Number
+
 import numpy as np
-from subprocess import CalledProcessError
-
 import kalasiris as isis
+import pvl
 
 
-def point_info(cube_path, x, y, point_type, allow_outside=False):
+def point_info(
+        cube_path: os.PathLike,
+        x,
+        y,
+        point_type: str,
+        allowoutside=False
+):
     """
-    Use Isis's campt to get image/ground point info from an image
+    Returns a pvl.collections.MutableMappingSequence object or a
+    Sequence of MutableMappingSequence objects which contain keys
+    and values derived from the output of ISIS campt or mappt on
+    the *cube_path*.
+
+    If x and y are single numbers, then a single MutableMappingSequence
+    object will be returned.  If they are Sequences or Numpy arrays, then a
+    Sequence of MutableMappingSequence objects will be returned,
+    such that the first MutableMappingSequence object of the returned
+    Sequence will correspond to the result of *x[0]* and *y[0]*,
+    etc.
+
+    Raises subprocess.CalledProcessError if campt or mappt have failures.
+    May raise ValueError if campt completes, but reports errors.
 
     Parameters
     ----------
-    cube_path : str
-                path to the input cube
+    cube_path : os.PathLike
+                Path to the input cube.
 
-    x : float
-        point in the x direction. Either a sample or a longitude value
-        depending on the point_type flag
+    x : Number, Sequence of Numbers, or Numpy Array
+        Point(s) in the x direction. Interpreted as either a sample
+        or a longitude value determined by *point_type*.
 
-    y : float
-        point in the y direction. Either a line or a latitude value
-        depending on the point_type flag
+    y : Number, Sequence of Numbers, or Numpy Array
+        Point(s) in the y direction. Interpreted as either a line
+        or a latitude value determined by *point_type*.
 
     point_type : str
                  Options: {"image", "ground"}
                  Pass "image" if  x,y are in image space (sample, line) or
-                 "ground" if in ground space (longitude, lattiude)
+                 "ground" if in ground space (longitude, latitude)
 
-    Returns
-    -------
-    : PvlObject
-      Pvl object containing campt returns
+    allowoutside: bool
+                  Defaults to False, this parameter is passed to campt
+                  or mappt.  Please read the ISIS documentation to
+                  learn more about this parameter.
+
     """
-    point_type = point_type.lower()
+    point_type = point_type.casefold()
+    valid_types = {"image", "ground"}
+    if point_type not in valid_types:
+        raise ValueError(
+            f'{point_type} is not a valid point type, valid types are '
+            f'{valid_types}'
+        )
 
-    if point_type not in {"image", "ground"}:
-        raise Exception(f'{point_type} is not a valid point type, valid types are ["image", "ground"]')
-
-
-    if isinstance(x, Number) and isinstance(y, Number):
-        x, y = [x], [y]
+    if isinstance(x, abc.Sequence) and isinstance(y, abc.Sequence):
+        if len(x) != len(y):
+            raise IndexError(
+                f"Sequences given to x and y must be of the same length."
+            )
+        x_coords = x
+        y_coords = y
+    elif isinstance(x, Number) and isinstance(y, Number):
+        x_coords = [x, ]
+        y_coords = [y, ]
+    elif isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
+        if not all((x.ndim == 1, y.ndim == 1)):
+            raise IndexError(
+                f"If they are numpy arrays, x and y must be one-dimensional, "
+                f"they were: {x.ndim} and {y.ndim}"
+            )
+        if x.shape != y.shape:
+            raise IndexError(
+                f"Numpy arrays given to x and y must be of the same shape."
+            )
+        x_coords = x
+        y_coords = y
+    else:
+        raise TypeError(
+            f"The values of x and y were neither Sequences nor individual "
+            f"numbers, they were: {x} and {y}"
+        )
 
     if point_type == "image":
         # convert to ISIS pixels
-        x = np.add(x, .5)
-        y = np.add(y, .5)
+        for i in range(len(x_coords)):
+            x_coords[i] += 0.5
+            y_coords[i] += 0.5
 
+    results = []
     if pvl.load(cube_path).get("IsisCube").get("Mapping"):
-      pvlres = []
-      # We have a projected image
-      for x,y in zip(x,y):
-        try:
-          if point_type.lower() == "ground":
-            pvlres.append(
-                isis.mappt(
-                    cube_path,
-                    longitude=x,
-                    latitude=y,
-                    allowoutside=allow_outside,
-                    coordsys="UNIVERSAL",
-                    type=point_type
-                ).stdout
-            )
-          elif point_type.lower() == "image":
-            pvlres.append(
-                isis.mappt(
-                    cube_path,
-                    sample=x,
-                    line=y,
-                    allowoutside=allow_outside,
-                    type=point_type
-                    ).stdout
-            )
-        except CalledProcessError as e:
-          print(f"MAPPT call failed, image: {cube_path}\n{e.stderr}")
-          return
-      dictres = [dict(pvl.loads(res)["Results"]) for res  in pvlres]
-      if len(dictres) == 1:
-        pvlres = dictres[0]
+        # We have a projected image, and must use mappt
+        mappt_common_args = dict(allowoutside=allowoutside, type=point_type)
 
+        for xx, yy in zip(x_coords, y_coords):
+            mappt_args = {
+                "ground": dict(
+                    longitude=xx,
+                    latitude=yy,
+                    coordsys="UNIVERSAL"
+                ),
+                "image": dict(
+                    sample=xx,
+                    line=yy,
+                )
+            }
+            for k in mappt_args.keys():
+                mappt_args[k].update(mappt_common_args)
+
+            results.append(pvl.loads(
+                isis.mappt(cube_path, **mappt_args[point_type]).stdout
+            )["Results"])
     else:
+        # Not projected, use campt
         if point_type == "ground":
             # campt uses lat, lon for ground but sample, line for image.
             # So swap x,y for ground-to-image calls
-            x, y = y, x
-
-        # ISIS's campt wants points in a file, so write to a temp file
-        with isis.fromlist.temp(
-                [f"{xval}, {yval}" for xval, yval in zip(x, y)]
-        ) as f:
-            try:
-                cp = isis.campt(
-                    cube_path,
-                    coordlist=f,
-                    allowoutside=allow_outside,
-                    usecoordlist=True,
-                    coordtype=point_type
-                )
-            except CalledProcessError as e:
-                warn(f"CAMPT call failed, image: {cube_path}\n{e.stderr}")
-                return
-
-        pvlres = pvl.loads(cp.stdout)
-        dictres = []
-        if len(x) > 1 and len(y) > 1:
-            for r in pvlres.getall("GroundPoint"):
-                if r['Error'] is not None:
-                    raise CalledProcessError(
-                        returncode=1,
-                        cmd=cp.args,
-                        stdout=r,
-                        stderr=r['Error'])
-                else:
-                    # convert all pixels to PLIO pixels from ISIS
-                    r["Sample"] -= .5
-                    r["Line"] -= .5
-                    dictres.append(dict(r))
+            p_list = [f"{lat}, {lon}" for lon, lat in zip(x_coords, y_coords)]
         else:
-            if pvlres['GroundPoint']['Error'] is not None:
-                # This probably isn't the right exception to call.
-                raise CalledProcessError(
-                    returncode=1,
-                    cmd=cp.args,
-                    # stdout=pvlres,
-                    # stderr=pvlres['GroundPoint']['Error']
-                )
+            p_list = [
+                f"{samp}, {line}" for samp, line in zip(x_coords, y_coords)
+            ]
+
+        # ISIS's campt needs points in a file
+        with isis.fromlist.temp(p_list) as f:
+            cp = isis.campt(
+                cube_path,
+                coordlist=f,
+                allowoutside=allowoutside,
+                usecoordlist=True,
+                coordtype=point_type
+            )
+
+        camres = pvl.loads(cp.stdout)
+        for r in camres.getall("GroundPoint"):
+            if r['Error'] is None:
+                # convert all pixels to PLIO pixels from ISIS
+                r["Sample"] -= .5
+                r["Line"] -= .5
+                results.append(r)
             else:
-                pvlres["GroundPoint"]["Sample"] -= .5
-                pvlres["GroundPoint"]["Line"] -= .5
-                dictres = dict(pvlres["GroundPoint"])
-    return dictres
+                raise ValueError(
+                    f"ISIS campt completed, but reported an error: {r['Error']}"
+                )
+
+    if isinstance(x, (abc.Sequence, np.ndarray)):
+        return results
+    else:
+        return results[0]
 
 
-def image_to_ground(cube_path, sample, line, lattype="PlanetocentricLatitude", lonttype="PositiveEast360Longitude"):
+def image_to_ground(
+        cube_path: os.PathLike,
+        sample,
+        line,
+        lontype="PositiveEast360Longitude",
+        lattype="PlanetocentricLatitude",
+):
     """
-    Use Isis's campt to convert a line sample point on an image to lat lon
+    Returns a two-tuple of numpy arrays or a two-tuple of floats, where
+    the first element of the tuple is the longitude(s) and the second
+    element are the latitude(s) that represent the coordinate(s) of the
+    input *sample* and *line* in *cube_path*.
 
-    Returns
-    -------
-    lats : np.array, float
-           1-D array of latitudes or single floating point latitude
+    If *sample* and *line* are single numbers, then the returned two-tuple
+    will have single elements. If they are Sequences, then the returned
+    two-tuple will contain numpy arrays.
 
-    lons : np.array, float
-           1-D array of longitudes or single floating point longitude
+    Raises the same exceptions as point_info().
+
+    Parameters
+    ----------
+    cube_path : os.PathLike
+                Path to the input cube.
+
+    sample : Number or Sequence of Numbers
+        Sample coordinate(s).
+
+    line : Number or Sequence of Numbers
+        Line coordinate(s).
+
+    lontype: str
+        Name of key to query in the campt or mappt return to get the returned
+        longitudes. Defaults to "PositiveEast360Longitude", but other values
+        are possible. Please see the campt or mappt documentation.
+
+    lattype: str
+        Name of key to query in the campt or mappt return to get the returned
+        latitudes. Defaults to "PlanetocentricLatitude", but other values
+        are possible.  Please see the campt or mappt documentation.
 
     """
     res = point_info(cube_path, sample, line, "image")
 
-    try:
-        if isinstance(res, list):
-            lats, lons = np.asarray([[r[lattype].value, r[lonttype].value] for r in res]).T
-        else:
-            lats, lons = res[lattype].value, res[lonttype].value
-    except Exception as e:
-        if isinstance(res, list):
-            lats, lons = np.asarray([[r[lattype], r[lonttype]] for r in res]).T
-        else:
-            lats, lons = res[lattype], res[lonttype]
-    return lats, lons
+    if isinstance(sample, (abc.Sequence, np.ndarray)):
+        lons, lats = np.asarray([
+            [r[lontype], r[lattype]] for r in res
+        ]).T
+    else:
+        lons, lats = res[lontype].value, res[lattype].value
+
+    return lons, lats
 
 
 def ground_to_image(cube_path, lon, lat):
     """
-    Use Isis's campt to convert a lat lon point to line sample in
-    an image
+    Returns a two-tuple of numpy arrays or a two-tuple of floats, where
+    the first element of the tuple is the sample(s) and the second
+    element are the lines(s) that represent the coordinate(s) of the
+    input *lon* and *lat* in *cube_path*.
 
-    Returns
-    -------
-    lines : np.array, float
-            array of lines or single floating point line
+    If *lon* and *lat* are single numbers, then the returned two-tuple
+    will have single elements. If they are Sequences, then the returned
+    two-tuple will contain numpy arrays.
 
-    samples : np.array, float
-              array of samples or single dloating point sample
+    Raises the same exceptions as point_info().
+
+    Parameters
+    ----------
+    cube_path : os.PathLike
+                Path to the input cube.
+
+    lon: Number or Sequence of Numbers
+        Longitude coordinate(s).
+
+    lat: Number or Sequence of Numbers
+        Latitude coordinate(s).
 
     """
     res = point_info(cube_path, lon, lat, "ground")
 
-    try:
-        if isinstance(res, list):
-            lines, samples = np.asarray([[r["Line"], r["Sample"]] for r in res]).T
-        else:
-            lines, samples =  res["Line"], res["Sample"]
-    except:
-        raise Exception(res)
+    if isinstance(lon, (abc.Sequence, np.ndarray)):
+        samples, lines = np.asarray([[r["Sample"], r["Line"]] for r in res]).T
+    else:
+        samples, lines = res["Sample"], res["Line"]
 
-    return lines, samples
+    return samples, lines
 
 

--- a/autocnet/spatial/isis.py
+++ b/autocnet/spatial/isis.py
@@ -106,25 +106,26 @@ def point_info(cube_path, x, y, point_type, allow_outside=False):
         pvlres = pvl.loads(cp.stdout)
         dictres = []
         if len(x) > 1 and len(y) > 1:
-            for r in pvlres:
-                if r['GroundPoint']['Error'] is not None:
+            for r in pvlres.getall("GroundPoint"):
+                if r['Error'] is not None:
                     raise CalledProcessError(
                         returncode=1,
-                        cmd=cp.cmd,
+                        cmd=cp.args,
                         stdout=r,
-                        stderr=r['GroundPoint']['Error'])
+                        stderr=r['Error'])
                 else:
                     # convert all pixels to PLIO pixels from ISIS
-                    r[1]["Sample"] -= .5
-                    r[1]["Line"] -= .5
-                    dictres.append(dict(r[1]))
+                    r["Sample"] -= .5
+                    r["Line"] -= .5
+                    dictres.append(dict(r))
         else:
             if pvlres['GroundPoint']['Error'] is not None:
+                # This probably isn't the right exception to call.
                 raise CalledProcessError(
                     returncode=1,
-                    cmd=cp.cmd,
-                    stdout=pvlres,
-                    stderr=pvlres['GroundPoint']['Error']
+                    cmd=cp.args,
+                    # stdout=pvlres,
+                    # stderr=pvlres['GroundPoint']['Error']
                 )
             else:
                 pvlres["GroundPoint"]["Sample"] -= .5

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -186,7 +186,7 @@ def place_points_in_overlap(overlap,
             # reference against which all other images are registered.
             if cam_type == "isis":
                 try:
-                    line, sample = isis.ground_to_image(node["image_path"], lon, lat)
+                    sample, line = isis.ground_to_image(node["image_path"], lon, lat)
                 except CalledProcessError as e:
                     if 'Requested position does not project in camera model' in e.stderr:
                         print(f'point ({lon}, {lat}) does not project to reference image {node["image_path"]}')
@@ -292,7 +292,7 @@ def place_points_in_overlap(overlap,
                 sample, line = image_coord.samp, image_coord.line
             if cam_type == "isis":
                 try:
-                    line, sample = isis.ground_to_image(node["image_path"], updated_lon, updated_lat)
+                    sample, line = isis.ground_to_image(node["image_path"], updated_lon, updated_lat)
                 except CalledProcessError as e:
                     if 'Requested position does not project in camera model' in e.stderr:
                         print(f'interesting point ({updated_lon},{updated_lat}) does not project to image {node["image_path"]}')
@@ -400,7 +400,7 @@ def place_points_in_image(image,
         node = nodes[0]
         if cam_type == "isis":
             try:
-                line, sample = isis.ground_to_image(node["image_path"], lon, lat)
+                sample, line = isis.ground_to_image(node["image_path"], lon, lat)
             except CalledProcessError as e:
                 if 'Requested position does not project in camera model' in e.stderr:
                     print(f'point ({lon}, {lat}) does not project to reference image {node["image_path"]}')
@@ -498,7 +498,7 @@ def place_points_in_image(image,
                 sample, line = image_coord.samp, image_coord.line
             if cam_type == "isis":
                 try:
-                    line, sample = isis.ground_to_image(node["image_path"], updated_lon, updated_lat)
+                    sample, line = isis.ground_to_image(node["image_path"], updated_lon, updated_lat)
                 except CalledProcessError as e:
                     if 'Requested position does not project in camera model' in e.stderr:
                         print(f'interesting point ({lon},{lat}) does not project to image {node["image_path"]}')
@@ -543,7 +543,7 @@ def add_measures_to_point(pointid, cam_type='isis', ncg=None, Session=None):
             
             if cam_type == "isis":
                 try:
-                    line, sample = isis.ground_to_image(image.path, point_lon, point_lat)
+                    sample, line = isis.ground_to_image(image.path, point_lon, point_lat)
                 except CalledProcessError as e:
                     if 'Requested position does not project in camera model' in e.stderr:
                         print(f'interesting point ({point_lon},{point_lat}) does not project to image {image.name}')

--- a/autocnet/spatial/overlap.py
+++ b/autocnet/spatial/overlap.py
@@ -1,5 +1,6 @@
 import warnings
 import json
+from subprocess import CalledProcessError
 
 from redis import StrictRedis
 import numpy as np
@@ -7,7 +8,6 @@ import pyproj
 import shapely
 import sqlalchemy
 from plio.io.io_gdal import GeoDataset
-from pysis.exceptions import ProcessError
 
 from autocnet.cg import cg as compgeom
 from autocnet.graph.node import NetworkNode
@@ -187,7 +187,7 @@ def place_points_in_overlap(overlap,
             if cam_type == "isis":
                 try:
                     line, sample = isis.ground_to_image(node["image_path"], lon, lat)
-                except ProcessError as e:
+                except CalledProcessError as e:
                     if 'Requested position does not project in camera model' in e.stderr:
                         print(f'point ({lon}, {lat}) does not project to reference image {node["image_path"]}')
                         continue
@@ -230,7 +230,7 @@ def place_points_in_overlap(overlap,
         if cam_type == "isis":
             try:
                 p = isis.point_info(node["image_path"], newsample, newline, point_type="image")
-            except ProcessError as e:
+            except CalledProcessError as e:
                 if 'Requested position does not project in camera model' in e.stderr:
                     print(node["image_path"])
                     print(f'interesting point ({newsample}, {newline}) does not project back to ground')
@@ -293,7 +293,7 @@ def place_points_in_overlap(overlap,
             if cam_type == "isis":
                 try:
                     line, sample = isis.ground_to_image(node["image_path"], updated_lon, updated_lat)
-                except ProcessError as e:
+                except CalledProcessError as e:
                     if 'Requested position does not project in camera model' in e.stderr:
                         print(f'interesting point ({updated_lon},{updated_lat}) does not project to image {node["image_path"]}')
                         continue
@@ -401,7 +401,7 @@ def place_points_in_image(image,
         if cam_type == "isis":
             try:
                 line, sample = isis.ground_to_image(node["image_path"], lon, lat)
-            except ProcessError as e:
+            except CalledProcessError as e:
                 if 'Requested position does not project in camera model' in e.stderr:
                     print(f'point ({lon}, {lat}) does not project to reference image {node["image_path"]}')
                     continue
@@ -434,7 +434,7 @@ def place_points_in_image(image,
         if cam_type == "isis":
             try:
                 p = isis.point_info(node["image_path"], newsample, newline, point_type="image")
-            except ProcessError as e:
+            except CalledProcessError as e:
                 if 'Requested position does not project in camera model' in e.stderr:
                     print(node["image_path"])
                     print(f'interesting point ({newsample}, {newline}) does not project back to ground')
@@ -499,7 +499,7 @@ def place_points_in_image(image,
             if cam_type == "isis":
                 try:
                     line, sample = isis.ground_to_image(node["image_path"], updated_lon, updated_lat)
-                except ProcessError as e:
+                except CalledProcessError as e:
                     if 'Requested position does not project in camera model' in e.stderr:
                         print(f'interesting point ({lon},{lat}) does not project to image {node["image_path"]}')
                         insert = False
@@ -544,7 +544,7 @@ def add_measures_to_point(pointid, cam_type='isis', ncg=None, Session=None):
             if cam_type == "isis":
                 try:
                     line, sample = isis.ground_to_image(image.path, point_lon, point_lat)
-                except ProcessError as e:
+                except CalledProcessError as e:
                     if 'Requested position does not project in camera model' in e.stderr:
                         print(f'interesting point ({point_lon},{point_lat}) does not project to image {image.name}')
 

--- a/autocnet/spatial/tests/test_isis.py
+++ b/autocnet/spatial/tests/test_isis.py
@@ -19,6 +19,39 @@ import kalasiris as isis
 
 from autocnet.spatial import isis as si
 
+class TestErrors(unittest.TestCase):
+
+    def test_point_info(self):
+        self.assertRaises(
+            ValueError, si.point_info, "dummy.cub", 10, 10, "bogus"
+        )
+        self.assertRaises(
+            IndexError,
+            si.point_info,
+            "dummy.cub",
+            [10, 20, 30],
+            [10, 20],
+            "image"
+        )
+        self.assertRaises(
+            TypeError, si.point_info, "dummy.cub", {10, 20}, {10, 20}, "image"
+        )
+        self.assertRaises(
+            IndexError,
+            si.point_info,
+            "dummy.cub",
+            np.array([[1, 2], [3, 4]]),
+            np.array([1, 2, 3, 4]),
+            "image"
+        )
+        self.assertRaises(
+            IndexError,
+            si.point_info,
+            "dummy.cub",
+            np.array([1, 2, 3, 4, 5]),
+            np.array([1, 2, 3, 4]),
+            "image"
+        )
 
 class TestISIS(unittest.TestCase):
 
@@ -48,6 +81,10 @@ class TestISIS(unittest.TestCase):
             Path("print.prt").unlink()
 
     def test_point_info(self):
+        self.assertRaises(
+            ValueError, si.point_info, self.cube, -10, -10, "image"
+        )
+
         d = si.point_info(self.cube, 10, 10, "image")
         self.assertEqual(10, d["Sample"])
         self.assertEqual(10, d["Line"])
@@ -73,34 +110,34 @@ class TestISIS(unittest.TestCase):
 
         d4 = si.point_info(self.map, 10, 10, "image")
         d5 = si.point_info(self.map, [10, x_sample], [10, y_line], "image")
-        self.assertEqual(d4, [d5[0]])
+        self.assertEqual(d4, d5[0])
 
-        d6 = si.point_info(self.map, x_lon, y_lat, "ground")[0]
+        d6 = si.point_info(self.map, x_lon, y_lat, "ground")
         self.assertEqual(961.20490394075, d6["Sample"])
         self.assertEqual(3959.4515093358, d6["Line"])
 
     def test_image_to_ground(self):
-        lat, lon = si.image_to_ground(self.cube, 20, 20)
+        lon, lat = si.image_to_ground(self.cube, 20, 20)
         self.assertEqual(274.14948072713, lon)
         self.assertEqual(28.537396673529, lat)
 
-        lats, lons = si.image_to_ground(
+        lons, lats = si.image_to_ground(
             self.map, np.array([10, 20]), np.array([10, 20])
         )
-        npt.assert_allclose(np.array([274.13903475, 274.13914465]), lons)
-        npt.assert_allclose(np.array([28.57550764, 28.57541113]), lats)
+        npt.assert_allclose(np.array([274.13902925, 274.13913915]), lons)
+        npt.assert_allclose(np.array([28.57551247, 28.57541596]), lats)
 
     def test_ground_to_image(self):
-        line, sample = si.ground_to_image(
+        sample, line = si.ground_to_image(
             self.cube, 274.14948072713, 28.537396673529
         )
-        self.assertEqual(20.004109124452, line)
         self.assertEqual(20.001087366213, sample)
+        self.assertEqual(20.004109124452, line)
 
-        lines, samples = si.ground_to_image(
+        samples, lines = si.ground_to_image(
             self.map,
             np.array([274.13903475, 274.14948072713]),
             np.array([28.57550764, 28.57541113])
         )
-        npt.assert_allclose(np.array([10.49999466, 20.50009032]), lines)
         npt.assert_allclose(np.array([10.5001324, 961.03569217]), samples)
+        npt.assert_allclose(np.array([10.49999466, 20.50009032]), lines)

--- a/autocnet/spatial/tests/test_isis.py
+++ b/autocnet/spatial/tests/test_isis.py
@@ -1,0 +1,106 @@
+"""This module has tests for the isis functions."""
+
+# This is free and unencumbered software released into the public domain.
+#
+# The authors of autocnet do not claim copyright on the contents of this file.
+# For more details about the LICENSE terms and the AUTHORS, you will
+# find files of those names at the top level of this repository.
+#
+# SPDX-License-Identifier: CC0-1.0
+
+import contextlib
+import unittest
+from pathlib import Path
+
+import numpy as np
+import numpy.testing as npt
+
+import kalasiris as isis
+
+from autocnet.spatial import isis as si
+
+
+class TestISIS(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.resourcedir = Path("test-resources")
+        self.red50img = self.resourcedir / "PSP_010502_2090_RED5_0.img"
+        self.red51img = self.resourcedir / "PSP_010502_2090_RED5_1.img"
+
+        if not all((self.red50img.exists(), self.red51img.exists())):
+            self.skipTest(
+                f"One or more files is missing from the "
+                f"{self.resourcedir.resolve()} directory. "
+                f"Tests on real files skipped."
+            )
+
+        self.cube = self.red50img.with_suffix(".TestISIS.cub")
+        isis.hi2isis(self.red50img, to=self.cube)
+        isis.spiceinit(self.cube)
+
+        self.map = self.cube.with_suffix(".map.cub")
+        isis.cam2map(self.cube, to=self.map)
+
+    def tearDown(self):
+        with contextlib.suppress(FileNotFoundError):
+            self.cube.unlink()
+            self.map.unlink()
+            Path("print.prt").unlink()
+
+    def test_point_info(self):
+        d = si.point_info(self.cube, 10, 10, "image")
+        self.assertEqual(10, d["Sample"])
+        self.assertEqual(10, d["Line"])
+        self.assertEqual(28.537311831691, d["PlanetocentricLatitude"].value)
+        self.assertEqual(274.14960455269, d["PositiveEast360Longitude"].value)
+
+        x_sample = 20
+        x_lon = 274.14948072713
+        y_line = 20
+        y_lat = 28.537396673529
+
+        d2 = si.point_info(self.cube, [10, x_sample], [10, y_line], "image")
+        self.assertEqual(x_sample, d2[1]["Sample"])
+        self.assertEqual(y_line, d2[1]["Line"])
+        self.assertEqual(y_lat, d2[1]["PlanetocentricLatitude"].value)
+        self.assertEqual(x_lon, d2[1]["PositiveEast360Longitude"].value)
+
+        self.assertEqual(d, d2[0])
+
+        d3 = si.point_info(self.cube, x_lon, y_lat, "ground")
+        self.assertEqual(20.001087366213, d3["Sample"])
+        self.assertEqual(20.004109124452, d3["Line"])
+
+        d4 = si.point_info(self.map, 10, 10, "image")
+        d5 = si.point_info(self.map, [10, x_sample], [10, y_line], "image")
+        self.assertEqual(d4, [d5[0]])
+
+        d6 = si.point_info(self.map, x_lon, y_lat, "ground")[0]
+        self.assertEqual(961.20490394075, d6["Sample"])
+        self.assertEqual(3959.4515093358, d6["Line"])
+
+    def test_image_to_ground(self):
+        lat, lon = si.image_to_ground(self.cube, 20, 20)
+        self.assertEqual(274.14948072713, lon)
+        self.assertEqual(28.537396673529, lat)
+
+        lats, lons = si.image_to_ground(
+            self.map, np.array([10, 20]), np.array([10, 20])
+        )
+        npt.assert_allclose(np.array([274.13903475, 274.13914465]), lons)
+        npt.assert_allclose(np.array([28.57550764, 28.57541113]), lats)
+
+    def test_ground_to_image(self):
+        line, sample = si.ground_to_image(
+            self.cube, 274.14948072713, 28.537396673529
+        )
+        self.assertEqual(20.004109124452, line)
+        self.assertEqual(20.001087366213, sample)
+
+        lines, samples = si.ground_to_image(
+            self.map,
+            np.array([274.13903475, 274.14948072713]),
+            np.array([28.57550764, 28.57541113])
+        )
+        npt.assert_allclose(np.array([10.49999466, 20.50009032]), lines)
+        npt.assert_allclose(np.array([10.5001324, 961.03569217]), samples)

--- a/autocnet/utils/hirise.py
+++ b/autocnet/utils/hirise.py
@@ -6,13 +6,12 @@ import geopandas as gpd
 import kalasiris as isis
 from subprocess import CalledProcessError
 
-import plio
 from plio.io.io_gdal import GeoDataset
 
 from shapely import wkt
 import numpy as np
 import pvl
-from shapely.geometry import Point, MultiPolygon
+
 
 def segment_hirise(directory, offset=300):
     images = glob(os.path.join(directory, "*RED*.stitched.norm.cub"))
@@ -58,7 +57,12 @@ def load_segments(directory):
 
 def ingest_hirise(directory):
 
-    l = glob(os.path.join(directory, "*RED*.IMG"))
+    # This function is very brittle attempting to guess filenames in the
+    # provided directory.  Much better to have this take a list of Path
+    # objects and operate on them, and leave it up to the user (or some
+    # convenience function) to figure out how to create that list.
+    l = glob(os.path.join(directory, "*RED*.IMG")) + \
+        glob(os.path.join(directory, "*RED*.img"))
     l = [os.path.splitext(i)[0] for i in l]
     print(l)
     cube_name = "_".join(os.path.splitext(os.path.basename(l[0]))[0].split("_")[:-2])
@@ -109,7 +113,7 @@ def ingest_hirise(directory):
                 """
             )
         )
-        return
+    return
 
 
 

--- a/autocnet/utils/tests/test_hirise.py
+++ b/autocnet/utils/tests/test_hirise.py
@@ -1,0 +1,60 @@
+"""This module has tests for the change_detection functions."""
+
+# This is free and unencumbered software released into the public domain.
+#
+# The authors of autocnet do not claim copyright on the contents of this file.
+# For more details about the LICENSE terms and the AUTHORS, you will
+# find files of those names at the top level of this repository.
+#
+# SPDX-License-Identifier: CC0-1.0
+
+import contextlib
+import unittest
+from pathlib import Path
+from subprocess import CalledProcessError
+from unittest.mock import patch
+
+from autocnet.utils import hirise
+
+class TestISIS(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.resourcedir = Path("test-resources")
+        red50img = self.resourcedir / "PSP_010502_2090_RED5_0.img"
+        red51img = self.resourcedir / "PSP_010502_2090_RED5_1.img"
+
+        if not all((red50img.exists(), red51img.exists())):
+            self.skipTest(
+                f"One or more files is missing from the {self.resourcedir} "
+                "directory. Tests on real files skipped.")
+
+    def tearDown(self):
+        with contextlib.suppress(FileNotFoundError):
+            for g in ("*.cub", "*.log"):
+                for p in self.resourcedir.glob(g):
+                    p.unlink()
+            Path("print.prt").unlink()
+
+    def test_ingest_hirise(self):
+        hirise.ingest_hirise(str(self.resourcedir))
+        self.assertTrue((
+            self.resourcedir / "PSP_010502_2090_RED5.stitched.norm.cub"
+        ).exists())
+
+        with patch(
+            "kalasiris.hi2isis",
+                side_effect=CalledProcessError(returncode=1, cmd="foo")
+        ):
+            hirise.ingest_hirise(str(self.resourcedir))
+
+    def test_segment_hirise(self):
+        hirise.ingest_hirise(str(self.resourcedir))
+        hirise.segment_hirise(str(self.resourcedir))
+        base = self.resourcedir / "PSP_010502_2090_RED5.stitched.norm.cub"
+        for f in (
+            base.with_suffix(".1_1325.cub"),
+            base.with_suffix(".725_2349.cub"),
+            base.with_suffix(".1749_3373.cub"),
+            base.with_suffix(".2773_4000.cub"),
+        ):
+            self.assertTrue(f.exists())

--- a/bin/acn_cd
+++ b/bin/acn_cd
@@ -3,6 +3,8 @@
 import sys
 import os
 import argparse
+from subprocess import CalledProcessError
+import textwrap
 from argparse import RawTextHelpFormatter
 import yaml
 import tempfile
@@ -23,9 +25,7 @@ import numpy as np
 
 from affine import Affine
 
-import pysis
-from pysis.exceptions import ProcessError
-from pysis import isis
+import kalasiris as isis
 
 import warnings
 warnings.simplefilter("ignore")
@@ -128,25 +128,41 @@ if __name__ == "__main__":
         cg.to_isis(cnet_path)
 
         try:
-            output = isis.jigsaw(fromlist=filelist_path, cnet=cnet_path, onet=cnet_path, update="yes", **config['jigsaw'])
-            print(output.decode())
-        except ProcessError as e:
-            print(e.stdout.decode('utf-8'))
-            print(e.stderr)
-            exit()
+            print(isis.jigsaw(
+                fromlist=filelist_path,
+                cnet=cnet_path,
+                onet=cnet_path,
+                update="yes",
+                **config['jigsaw']
+            ).stdout)
 
-        if args.write_registered_cubes:
-            before_proj = os.path.splitext(args.before)[0] + ".proj.cub"
-            after_proj = os.path.splitext(args.after)[0] + ".proj.cub"
-        else: # use the temp directory
-            before_proj = os.path.join(dirpath, "before.cub")
-            after_proj = os.path.join(dirpath, "after.cub")
+            if args.write_registered_cubes:
+                before_proj = os.path.splitext(args.before)[0] + ".proj.cub"
+                after_proj = os.path.splitext(args.after)[0] + ".proj.cub"
+            else: # use the temp directory
+                before_proj = os.path.join(dirpath, "before.cub")
+                after_proj = os.path.join(dirpath, "after.cub")
 
-        try:
             isis.cam2map(from_=args.before, to=before_proj, map=args.map)
-            isis.cam2map(from_=args.after, to=after_proj, patchsize=8, map=before_proj, matchmap=True, warpalgorithm="REVERSEPATCH")
-        except ProcessError as e:
-            print(e.stderr)
+            isis.cam2map(
+                from_=args.after,
+                to=after_proj,
+                patchsize=8,
+                map=before_proj,
+                matchmap=True,
+                warpalgorithm="REVERSEPATCH"
+            )
+        except CalledProcessError as e:
+            print(
+                textwrap.dedent(
+                    f"""\
+                    Had a subprocess error:
+                    {' '.join(e.cmd)}
+                    {e.stdout}
+                    {e.stderr}
+                    """
+                )
+            )
             exit()
 
         args.before = before_proj
@@ -159,9 +175,22 @@ if __name__ == "__main__":
         # Requires sub solar azmith
         ssa_path = "/tmp/ssa.cub" # os.path.join(dirpath, 'ssa.cub')
         try:
-            isis.phocube(from_=args.before, to=ssa_path, subsolargroundazimuth=True)
-        except ProcessError as e:
-            print(e.stderr)
+            isis.phocube(
+                from_=args.before,
+                to=ssa_path,
+                subsolargroundazimuth=True
+            )
+        except CalledProcessError as e:
+            print(
+                textwrap.dedent(
+                    f"""\
+                    Had a subprocess error:
+                    {' '.join(e.cmd)}
+                    {e.stdout}
+                    {e.stderr}
+                    """
+                )
+            )
         print("created: ", ssa_path)
         ssa = GeoDataset(ssa_path).read_array(6)
         ret = _cd_functions_[args.algorithm.strip()](before_proj_geo, after_proj_geo, ssa, **config.get(args.algorithm, {}))

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,12 +17,12 @@ requirements:
       - dill=0.3.2
       - geoalchemy2
       - geopandas=0.8.1
+      - kalasiris
       - knoten>=0.2.1
       - networkx=2.4
       - opencv<=3.5
       - plio>=1.2.3
       - plurmy>=0.1.1
-      - pysis>=0.1.1
       - pyyaml=5.3.1
       - redis-py
       - scikit-image=0.17.2
@@ -41,6 +41,7 @@ requirements:
       - imageio
       - ipykernel
       - jupyter
+      - kalasiris
       - knoten
       - ncurses
       - networkx
@@ -53,7 +54,6 @@ requirements:
       - pvl >= 1.0
       - psycopg2
       - pyproj
-      - pysis
       - pytest
       - pytest-cov
       - python>=3

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - imageio
   - ipykernel
   - jupyter
+  - kalasiris
   - knoten>= 0.2.0,<1.0
   - ncurses
   - networkx >=2, <3
@@ -32,7 +33,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  - pysis
   - richdem
   - scikit-image>=0.17
   - scikit-learn

--- a/notebooks/blob_detection.ipynb
+++ b/notebooks/blob_detection.ipynb
@@ -18,9 +18,8 @@
     "from autocnet.utils.utils import bytescale \n",
     "\n",
     "from plio.io.io_gdal import GeoDataset\n",
-    "import pysis\n",
-    "from pysis import isis\n",
-    "from pysis.exceptions import ProcessError\n"
+    "import kalasiris as isis\n",
+    "from subprocess import CalledProcessError\n"
    ]
   },
   {
@@ -46,7 +45,9 @@
     "# Run to create the subsolar azimuth band.  There is currently no option to output directly as array\n",
     "try:\n",
     "    isis.phocube(from_=roi1_proj, to='out.cub', subsolargroundazimuth=True)\n",
-    "except ProcessError as e:\n",
+    "except CalledProcessError as e:\n",
+    "    print(' '.join(e.cmd))\n",
+    "    print(e.stdout\n",
     "    print(e.stderr)"
    ]
   },
@@ -106,7 +107,7 @@
    "source": [
     "roi1_proj_geo = GeoDataset(roi1_proj)\n",
     "roi2_proj_geo = GeoDataset(roi2_proj)\n",
-    "isis_null = pysis.specialpixels.SPECIAL_PIXELS['Real']['Null']\n",
+    "isis_null = isis.specialpixels.Real.Null\n",
     "\n",
     "proj_array1 = roi1_proj_geo.read_array()\n",
     "proj_array2 = roi2_proj_geo.read_array()\n",

--- a/notebooks/hirise_registration.ipynb
+++ b/notebooks/hirise_registration.ipynb
@@ -27,8 +27,8 @@
     "from autocnet.cg import change_detection as cd\n",
     "\n",
     "from plio.io.io_gdal import GeoDataset\n",
-    "from pysis import isis\n",
-    "from pysis.exceptions import ProcessError\n",
+    "import kalasiris as isis\n",
+    "from subprocess import CalledProcessError\n",
     "\n",
     "from IPython.display import display\n",
     "\n",
@@ -478,8 +478,10 @@
    "source": [
     "try:\n",
     "    output = isis.jigsaw(fromlist='test.lis', cnet='test.net', onet='bundle_test.cnet', update='yes', radius='yes', errorpropagation='yes', outlier_rejection='yes', point_longitude_sigma=10, point_latitude_sigma=10, point_radius_sigma=2, maxits=20, camsolve='VELOCITIES', twist='yes', overexisting='yes', spsolve='NONE')\n",
-    "    print(output.decode())\n",
-    "except ProcessError as e:\n",
+    "    print(output.stdout)\n",
+    "except CalledProcessError as e:\n",
+    "    print(' '.join(e.cmd))\n",
+    "    print(e.stdout\n",
     "    print(e.stderr)"
    ]
   },
@@ -497,7 +499,9 @@
     "try:\n",
     "    isis.cam2map(from_=roi1_path, to=roi1_proj, map='/usgs/cpkgs/isis3/data/base/templates/maps/equirectangular.map')\n",
     "    isis.cam2map(from_=roi2_path, to=roi2_proj, patchsize=8, map=roi1_proj, matchmap=True, warpalgorithm=\"REVERSEPATCH\")\n",
-    "except ProcessError as e:\n",
+    "except CalledProcessError as e:\n",
+    "    print(' '.join(e.cmd))\n",
+    "    print(e.stdout\n",
     "    print(e.stderr)"
    ]
   },
@@ -535,7 +539,7 @@
     "import pysis\n",
     "roi1_proj_geo = GeoDataset(roi1_proj)\n",
     "roi2_proj_geo = GeoDataset(roi2_proj)\n",
-    "isis_null = pysis.specialpixels.SPECIAL_PIXELS['Real']['Null']\n",
+    "isis_null = isis.specialpixels.Real.Null\n",
     "\n",
     "proj_array1 = roi1_proj_geo.read_array()\n",
     "proj_array2 = roi2_proj_geo.read_array()\n",

--- a/notebooks/hirise_registration.ipynb
+++ b/notebooks/hirise_registration.ipynb
@@ -536,7 +536,6 @@
     }
    ],
    "source": [
-    "import pysis\n",
     "roi1_proj_geo = GeoDataset(roi1_proj)\n",
     "roi2_proj_geo = GeoDataset(roi2_proj)\n",
     "isis_null = isis.specialpixels.Real.Null\n",


### PR DESCRIPTION
* Converted everything I could find from *pysis* to *kalasiris*.
* Added tests for functions that used *kalasiris* in order to make sure I didn't screw anything up (fingers crossed).
* Added a Makefile with all kinds of functionality, but  specifically a "test-resources" target to download a pair of sample HiRISE files to run tests on.  If this directory isn't present, the tests that need them will be safely skipped.
* Reviewed the three functions in spatial/isis.py, and refactored them.
  * They were inconsistently returning single values or a list, now, if given a single value, they'll return a two-tuple of singletons, if they are given a Sequence or a Numpy array, they'll return a two-tuple of Sequences or Numpy arrays, as appropriate.
  * Coordinate order shall be: x then y, longitude then latitude, sample then line, anything else is confusing and wrong.  If thou takest arguments, thou shall takest them in that order.  If thou returnest values or array-likes in a tuple, thou shall returnest them in that order. Functions refactored to support that consistency, and also refactored functions that call these to also work under these new commandments.  The rest of the library probably needs to be scrubbed.

This is a lot to review, I know.  Sorry-not-sorry.
 
This would close #570 