### PR TITLE
image_to_ground fix

### DIFF
--- a/autocnet/spatial/isis.py
+++ b/autocnet/spatial/isis.py
@@ -308,13 +308,28 @@ def image_to_ground(
     res = point_info(cube_path, sample, line, "image")
 
     if isinstance(sample, (abc.Sequence, np.ndarray)):
-        lons, lats = np.asarray([
-            [r[lontype], r[lattype]] for r in res
-        ]).T
+        lon_list = list()
+        lat_list = list()
+        for r in res:
+            lon_list.append(_get_value(r[lontype]))
+            lat_list.append(_get_value(r[lattype]))
+
+        lons = np.asarray(lon_list)
+        lats = np.asarray(lat_list)
     else:
-        lons, lats = res[lontype].value, res[lattype].value
+        lons = _get_value(res[lontype])
+        lats = _get_value(res[lattype])
 
     return lons, lats
+
+
+def _get_value(obj):
+    """Returns *obj*, unless *obj* is of type pvl.collections.Quantity, in
+    which case, the .value component of the object is returned."""
+    if isinstance(obj, pvl.collections.Quantity):
+        return obj.value
+    else:
+        return obj
 
 
 def ground_to_image(cube_path, lon, lat):

--- a/autocnet/spatial/tests/test_isis.py
+++ b/autocnet/spatial/tests/test_isis.py
@@ -123,6 +123,12 @@ class TestISIS(unittest.TestCase):
         self.assertEqual(x, lon)
         self.assertEqual(y, lat)
 
+        lons, lats = si.image_to_ground(
+            self.cube, np.array([10, 20]), np.array([10, 20])
+        )
+        npt.assert_allclose(np.array([274.14961074425, x]), lons)
+        npt.assert_allclose(np.array([28.537307587569, y]), lats)
+
         lon, lat = si.image_to_ground(self.map, 20, 20)
         x = 274.13913915
         y = 28.57541596

--- a/autocnet/spatial/tests/test_isis.py
+++ b/autocnet/spatial/tests/test_isis.py
@@ -118,40 +118,62 @@ class TestISIS(unittest.TestCase):
 
     def test_image_to_ground(self):
         lon, lat = si.image_to_ground(self.cube, 20, 20)
-        x = 274.14948072713
-        y = 28.537396673529
-        self.assertEqual(x, lon)
-        self.assertEqual(y, lat)
+        x = 274.14948
+        y = 28.537396
+        self.assertAlmostEqual(x, lon, places=5)
+        self.assertAlmostEqual(y, lat, places=5)
 
         lons, lats = si.image_to_ground(
             self.cube, np.array([10, 20]), np.array([10, 20])
         )
-        npt.assert_allclose(np.array([274.14961074425, x]), lons)
-        npt.assert_allclose(np.array([28.537307587569, y]), lats)
+        npt.assert_allclose(np.array([274.14961, x]), lons, rtol=1e-05)
+        npt.assert_allclose(np.array([28.53731, y]), lats, rtol=1e-05)
 
         lon, lat = si.image_to_ground(self.map, 20, 20)
-        x = 274.13913915
-        y = 28.57541596
-        self.assertEqual(x, lon)
-        self.assertEqual(y, lat)
+        x = 274.13914
+        y = 28.57541
+        self.assertAlmostEqual(x, lon, places=5)
+        self.assertAlmostEqual(y, lat, places=5)
 
         lons, lats = si.image_to_ground(
             self.map, np.array([10, 20]), np.array([10, 20])
         )
-        npt.assert_allclose(np.array([274.13902925, x]), lons)
-        npt.assert_allclose(np.array([28.57551247, y]), lats)
+        npt.assert_allclose(np.array([274.13903, x]), lons, rtol=1e-05)
+        npt.assert_allclose(np.array([28.57551, y]), lats, rtol=1e-05)
 
     def test_ground_to_image(self):
+        lon = 274.14948072713
+        lat = 28.537396673529
+        goal_samp = 20.001087
+        goal_line = 20.004109
         sample, line = si.ground_to_image(
-            self.cube, 274.14948072713, 28.537396673529
+            self.cube, lon, lat
         )
-        self.assertEqual(20.001087366213, sample)
-        self.assertEqual(20.004109124452, line)
+        self.assertAlmostEqual(goal_samp, sample, places=6)
+        self.assertAlmostEqual(goal_line, line, places=6)
+
+        samples, lines = si.ground_to_image(
+            self.cube,
+            np.array([lon, 274.1495]),
+            np.array([lat, 28.5374])
+        )
+        npt.assert_allclose(np.array([goal_samp, 18.241668]), samples)
+        npt.assert_allclose(np.array([goal_line, 20.145382]), lines)
+
+        lon = 274.13903475
+        lat = 28.57550764
+        goal_samp = 10.5001324
+        goal_line = 10.49999466
+        sample, line = si.ground_to_image(
+            self.map, lon, lat
+        )
+        self.assertAlmostEqual(goal_samp, sample)
+        self.assertAlmostEqual(goal_line, line)
 
         samples, lines = si.ground_to_image(
             self.map,
-            np.array([274.13903475, 274.14948072713]),
-            np.array([28.57550764, 28.57541113])
+            np.array([lon, 274.14948072713]),
+            np.array([lat, 28.57541113])
         )
-        npt.assert_allclose(np.array([10.5001324, 961.03569217]), samples)
-        npt.assert_allclose(np.array([10.49999466, 20.50009032]), lines)
+        npt.assert_allclose(np.array([goal_samp, 961.03569217]), samples)
+        npt.assert_allclose(np.array([goal_line, 20.50009032]), lines)

--- a/autocnet/spatial/tests/test_isis.py
+++ b/autocnet/spatial/tests/test_isis.py
@@ -118,14 +118,22 @@ class TestISIS(unittest.TestCase):
 
     def test_image_to_ground(self):
         lon, lat = si.image_to_ground(self.cube, 20, 20)
-        self.assertEqual(274.14948072713, lon)
-        self.assertEqual(28.537396673529, lat)
+        x = 274.14948072713
+        y = 28.537396673529
+        self.assertEqual(x, lon)
+        self.assertEqual(y, lat)
+
+        lon, lat = si.image_to_ground(self.map, 20, 20)
+        x = 274.13913915
+        y = 28.57541596
+        self.assertEqual(x, lon)
+        self.assertEqual(y, lat)
 
         lons, lats = si.image_to_ground(
             self.map, np.array([10, 20]), np.array([10, 20])
         )
-        npt.assert_allclose(np.array([274.13902925, 274.13913915]), lons)
-        npt.assert_allclose(np.array([28.57551247, 28.57541596]), lats)
+        npt.assert_allclose(np.array([274.13902925, x]), lons)
+        npt.assert_allclose(np.array([28.57551247, y]), lats)
 
     def test_ground_to_image(self):
         sample, line = si.ground_to_image(


### PR DESCRIPTION
The `spatial/isis.py::image_to_ground()` function calls the `point_info()` function which just returns the results dictionary parsed from the PVL-text return of ISIS `mappt` or `campt`.  Turns out that while both return PVL-text with keys like `PlanetocentricLatitude` one of those ISIS programs returns just a plain numeric value, and the other returns a value and a unit.  To a PVL parser, those are different things, and one is returned as a `float` or `int` and the other is returned as a `pvl.collections.Quantity` object, from which the value can be extracted, but they are different kinds of objects, and `image_to_ground()` was not properly handling that duality.

Now it does.  More robust tests were added for image_to_ground() and ground_to_image(), just for good measure.

Would close #579, and is relevant to discussion in #578.