### PR TITLE
Fixes #584

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ release.
 ### Fixed
 - `update_from_jigsaw` failures due to stale code. Now uses a conntext on the engine to ensure closure
 - Fixes errors where reference measure index was being incorrectly tracked when placing measures would fail [#606](https://github.com/USGS-Astrogeology/autocnet/issues/606)
+-  Fixed #584 where importing autocnet fails on kalasiris imports by wrapping the import in a try accept.
 
 ## [0.6.0]
 

--- a/autocnet/spatial/isis.py
+++ b/autocnet/spatial/isis.py
@@ -239,7 +239,7 @@ def point_info(
 
         # ISIS's campt needs points in a file
         with isis.fromlist.temp(p_list) as f:
-            cp = campt(
+            cp = isis.campt(
                 cube_path,
                 coordlist=f,
                 allowoutside=allowoutside,

--- a/autocnet/spatial/isis.py
+++ b/autocnet/spatial/isis.py
@@ -18,9 +18,9 @@ import numpy as np
 
 try:
     import kalasiris as isis
-except:
+except Exception as exception:
     from autocnet.utils.utils import FailedImport
-    isis = FailedImport()
+    isis = FailedImport(exception)
 
 import pvl
 

--- a/autocnet/spatial/isis.py
+++ b/autocnet/spatial/isis.py
@@ -15,10 +15,14 @@ from collections import abc
 from numbers import Number
 
 import numpy as np
-import kalasiris as isis
-import pvl
 
-import kalasiris as kal
+try:
+    import kalasiris as isis
+except:
+    from autocnet.utils.utils import FailedImport
+    isis = FailedImport()
+
+import pvl
 
 isis2np_types = {
         "UnsignedByte" : "uint8",
@@ -48,7 +52,7 @@ def get_isis_special_pixels(arr):
 
     """
     isis_dtype = np2isis_types[str(arr.dtype)]
-    sp_pixels = getattr(kal.specialpixels, isis_dtype)
+    sp_pixels = getattr(isis.specialpixels, isis_dtype)
 
     null = np.argwhere(arr==sp_pixels.Null)
     lrs = np.argwhere(arr==sp_pixels.Lrs)
@@ -235,7 +239,7 @@ def point_info(
 
         # ISIS's campt needs points in a file
         with isis.fromlist.temp(p_list) as f:
-            cp = isis.campt(
+            cp = campt(
                 cube_path,
                 coordlist=f,
                 allowoutside=allowoutside,

--- a/autocnet/spatial/tests/test_isis.py
+++ b/autocnet/spatial/tests/test_isis.py
@@ -18,9 +18,9 @@ import numpy.testing as npt
 
 try:
     import kalasiris as isis
-except:
+except Exception as exception:
     from autocnet.utils.utils import FailedImport
-    isis = FailedImport()
+    isis = FailedImport(exception)
 
 from autocnet.spatial import isis as si
 

--- a/autocnet/spatial/tests/test_isis.py
+++ b/autocnet/spatial/tests/test_isis.py
@@ -15,7 +15,12 @@ from pathlib import Path
 import numpy as np
 import numpy.testing as npt
 
-import kalasiris as isis
+
+try:
+    import kalasiris as isis
+except:
+    from autocnet.utils.utils import FailedImport
+    isis = FailedImport()
 
 from autocnet.spatial import isis as si
 

--- a/autocnet/utils/utils.py
+++ b/autocnet/utils/utils.py
@@ -22,8 +22,10 @@ from shapely.ops import cascaded_union, polygonize
 
 
 class FailedImport():
-    def __getattribute__(self, name: str):
-        raise ImportError('Module was not imported. No classes, attributes, or variables are available.')
+    def __init__(self, exception):
+        self.exception = exception
+    def __getattr__(self, name: str):
+        raise self.exception
 
 def tile(array_size, tilesize=1000, overlap=500):
     stepsize = tilesize - overlap

--- a/autocnet/utils/utils.py
+++ b/autocnet/utils/utils.py
@@ -20,6 +20,11 @@ from shapely import geometry
 from shapely.geometry import MultiPoint
 from shapely.ops import cascaded_union, polygonize
 
+
+class FailedImport():
+    def __getattribute__(self, name: str):
+        raise ImportError('Module was not imported. No classes, attributes, or variables are available.')
+
 def tile(array_size, tilesize=1000, overlap=500):
     stepsize = tilesize - overlap
     if stepsize < 0:

--- a/bin/acn_cd
+++ b/bin/acn_cd
@@ -25,7 +25,11 @@ import numpy as np
 
 from affine import Affine
 
-import kalasiris as isis
+try:
+    import kalasiris as isis
+except:
+    from autocnet.utils.utils import FailedImport
+    isis = FailedImport()
 
 import warnings
 warnings.simplefilter("ignore")


### PR DESCRIPTION
This fixes #584, but making the kalasiris import optional. I solved this problem by wrapping the import in a try except. On the except, a FailedImport class is matched to the module name. Then any calls to the module using dot notation (that calls `__getattribute__` will raise an ImportError. This way, we can run any functions / methods in a file that do not use the import that failed.

To be even more explicit about what is happening is that kalasiris is attempting to import, but when the os.environ['ISISROOT'] call fails, the import raises. When that import raises, the except block in autocnet is triggered instantiating the FailedImport class.

## How was this tested?

I tested this in an interactive python session by importing autocnet.spatial.isis and then attempting to make use of an `isis.*` call. That module imports kalasiris as isis.

```
>>> from autocnet.spatial.isis import isis
>>> type(isis)
<class 'autocnet.utils.utils.FailedImport'>
>>> isis.campt
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jlaura/github/autocnet/autocnet/utils/utils.py", line 26, in __getattribute__
    raise ImportError('Module was not imported. No classes, attributes, or variables are available.')
ImportError: Module was not imported. No classes, attributes, or variables are available.
```