### PR TITLE
Missed Kalisiris imports fixed

### DIFF
--- a/autocnet/cg/change_detection.py
+++ b/autocnet/cg/change_detection.py
@@ -26,7 +26,12 @@ import richdem as rd
 import pandas as pd
 import geopandas as gpd
 
-from kalasiris import specialpixels
+try:
+    import kalasiris as isis
+except Exception as exception:
+    from autocnet.utils.utils import FailedImport
+    isis = FailedImport(exception)
+
 
 from autocnet.utils.utils import bytescale
 from autocnet.matcher.cpu_extractor import extract_features
@@ -57,7 +62,7 @@ def image_diff(arr1, arr2):
     arr1[arr1 == 0] = np.nan
     arr2[arr2 == 0] = np.nan
 
-    isis_null = specialpixels.Real.Null
+    isis_null = isis.specialpixels.Real.Null
     arr1[arr1 == isis_null] = np.nan
     arr2[arr2 == isis_null] = np.nan
 
@@ -92,7 +97,7 @@ def image_ratio(arr1, arr2):
     arr1[arr1 == 0] = np.nan
     arr2[arr2 == 0] = np.nan
 
-    isis_null = specialpixels.Real.Null
+    isis_null = isis.specialpixels.Real.Null
     arr1[arr1 == isis_null] = np.nan
     arr2[arr2 == isis_null] = np.nan
 

--- a/autocnet/cg/tests/test_change_detection.py
+++ b/autocnet/cg/tests/test_change_detection.py
@@ -12,7 +12,7 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 from autocnet.cg import change_detection as cd
-
+from autocnet.utils.utils import FailedImport
 
 class TestISIS(unittest.TestCase):
 
@@ -20,16 +20,18 @@ class TestISIS(unittest.TestCase):
         arr1 = np.array([1.0, 2.0, -3.4028227e+38])
         arr2 = np.array([1.0, 3.0, 0])
 
-        npt.assert_array_equal(
-            np.array([0, -1.0, 0]),
-            cd.image_diff(arr1, arr2)
-        )
+        if not isinstance(cd.isis, FailedImport):
+            npt.assert_array_equal(
+                np.array([0, -1.0, 0]),
+                cd.image_diff(arr1, arr2)
+            )
 
     def test_image_ratio(self):
         arr1 = np.array([1.0, 4.0, -3.4028227e+38])
         arr2 = np.array([1.0, 2.0, 0])
 
-        npt.assert_array_equal(
-            np.array([1.0, 2.0, 0]),
-            cd.image_ratio(arr1, arr2)
-        )
+        if not isinstance(cd.isis, FailedImport):
+            npt.assert_array_equal(
+                np.array([1.0, 2.0, 0]),
+                cd.image_ratio(arr1, arr2)
+            )

--- a/autocnet/utils/hirise.py
+++ b/autocnet/utils/hirise.py
@@ -3,7 +3,12 @@ from glob import glob
 import textwrap
 import geopandas as gpd
 
-import kalasiris as isis
+try:
+    import kalasiris as isis
+except Exception as exception:
+    from autocnet.utils.utils import FailedImport
+    isis = FailedImport(exception)
+    
 from subprocess import CalledProcessError
 
 from plio.io.io_gdal import GeoDataset


### PR DESCRIPTION
This PR catches two other Kalisiris imports that needed to be conditional and updates the change detection tests to support conditional imports of the ISIS dependency.

These fixes were needed to have a fully passing testing harness before starting work on a 1.0.0 release.